### PR TITLE
Update PromisesSwift

### DIFF
--- a/FlowCrypt/Controllers/Compose/ComposeViewController.swift
+++ b/FlowCrypt/Controllers/Compose/ComposeViewController.swift
@@ -212,7 +212,7 @@ extension ComposeViewController {
         showSpinner("sending_title".localized)
 
         Promise<Bool> { [weak self] in
-            try await(self!.encryptAndSendMessage())
+            try awaitPromise(self!.encryptAndSendMessage())
         }.then(on: .main) { [weak self] sent in
             if sent { // else it must have shown error to user
                 self?.handleSuccessfullySentMessage()
@@ -258,7 +258,7 @@ extension ComposeViewController {
                 to: recipients.map { $0.email }
             )
 
-            try await(self.messageSender.sendMail(mime: encrypted.mimeEncoded))
+            try awaitPromise(self.messageSender.sendMail(mime: encrypted.mimeEncoded))
 
             return true
         }

--- a/FlowCrypt/Controllers/Msg/MessageViewController.swift
+++ b/FlowCrypt/Controllers/Msg/MessageViewController.swift
@@ -140,7 +140,7 @@ extension MessageViewController {
         guard let input = input else { return }
         showSpinner("loading_title".localized, isUserInteractionEnabled: true)
         Promise { [weak self] in
-            self?.message = try await(self!.fetchMessage())
+            self?.message = try awaitPromise(self!.fetchMessage())
         }.then(on: .main) { [weak self] in
             self?.hideSpinner()
             self?.node.reloadRows(at: [Parts.text.indexPath], with: .fade)
@@ -155,7 +155,7 @@ extension MessageViewController {
         Promise { [weak self] resolve, reject in
             guard let self = self, let input = self.input else { return }
 
-            let rawMimeData: Data = try await(self.messageProvider.fetchMsg(message: input.objMessage, folder: input.path))
+            let rawMimeData: Data = try awaitPromise(self.messageProvider.fetchMsg(message: input.objMessage, folder: input.path))
             self.input?.bodyMessage = rawMimeData
 
             guard let keys = self.dataService.keys else {
@@ -266,8 +266,8 @@ extension MessageViewController {
 
         Promise<Bool> { [weak self] () -> Bool in
             guard let self = self else { throw AppErr.nilSelf }
-            guard try await(self.awaitUserConfirmation(title: "You're about to permanently delete a message")) else { return false }
-            try await(self.messageOperationsProvider.delete(message: input.objMessage, form: input.path))
+            guard try awaitPromise(self.awaitUserConfirmation(title: "You're about to permanently delete a message")) else { return false }
+            try awaitPromise(self.messageOperationsProvider.delete(message: input.objMessage, form: input.path))
             return true
         }
         .then(on: .main) { [weak self] didPerformOp in

--- a/FlowCrypt/Controllers/SignIn Other/EmailProviderViewController.swift
+++ b/FlowCrypt/Controllers/SignIn Other/EmailProviderViewController.swift
@@ -480,8 +480,8 @@ extension EmailProviderViewController {
         }
 
         Promise<Void> {
-            try await(self.imap.connectImap(session: imapSessionToCheck))
-            try await(self.imap.connectSmtp(session: smtpSession))
+            try awaitPromise(self.imap.connectImap(session: imapSessionToCheck))
+            try awaitPromise(self.imap.connectSmtp(session: smtpSession))
         }
         .then(on: .main) { [weak self] in
             self?.handleSuccessfulConnection()

--- a/FlowCrypt/Extensions/UIViewControllerExtensions.swift
+++ b/FlowCrypt/Extensions/UIViewControllerExtensions.swift
@@ -126,7 +126,7 @@ extension UIViewController {
         return Promise<Void> { [weak self] resolve, _ in
             guard let self = self else { throw AppErr.nilSelf }
             do {
-                _ = try await(promise)
+                _ = try awaitPromise(promise)
                 resolve(())
             } catch {
                 DispatchQueue.main.async {

--- a/FlowCrypt/Extensions/URLSessionExtension.swift
+++ b/FlowCrypt/Extensions/URLSessionExtension.swift
@@ -50,7 +50,7 @@ extension URLSession {
             guard url != nil else {
                 throw HttpErr(status: -2, data: Data(), error: AppErr.unexpected("Invalid url: \(urlStr)"))
             }
-            return try await(self.call(URLRequest(url: url!), tolerateStatus: tolerateStatus))
+            return try awaitPromise(self.call(URLRequest(url: url!), tolerateStatus: tolerateStatus))
         }
     }
 }

--- a/FlowCrypt/Functionality/DataManager/DataService.swift
+++ b/FlowCrypt/Functionality/DataManager/DataService.swift
@@ -138,9 +138,9 @@ extension DataService: DBMigration {
         return Promise<Void> { [weak self] in
             guard let self = self else { throw AppErr.nilSelf }
             // migrate to encrypted storage
-            try await(self.encryptedStorage.performMigrationIfNeeded())
+            try awaitPromise(self.encryptedStorage.performMigrationIfNeeded())
             // migrate all other type of migrations
-            try await(self.migrationService.performMigrationIfNeeded())
+            try awaitPromise(self.migrationService.performMigrationIfNeeded())
         }
     }
 }

--- a/FlowCrypt/Functionality/Mail Provider/Backup Provider/Gmail+Backup.swift
+++ b/FlowCrypt/Functionality/Mail Provider/Backup Provider/Gmail+Backup.swift
@@ -17,7 +17,7 @@ extension GmailService: BackupProvider {
                 .recoverAccountSearchSubject
                 .map { searchExpression(using: MessageSearchContext(expression: $0)) }
 
-            let backupMessages = try await(all(backupSearchExpressions))
+            let backupMessages = try awaitPromise(all(backupSearchExpressions))
                 .flatMap { $0 }
             let uniqueMessages = Set(backupMessages)
             let attachments = uniqueMessages
@@ -30,10 +30,7 @@ extension GmailService: BackupProvider {
                 .flatMap { $0 }
                 .map(findAttachment)
 
-            // TODO: - TOM 1
-            // Here I'm getting the correct number of attachments with backups (17 for cryptup.tester@gmail.com account)
-
-            let data = try await(all(attachments)).joined
+            let data = try awaitPromise(all(attachments)).joined
             resolve(data)
         }
     }

--- a/FlowCrypt/Functionality/Mail Provider/Contacts Provider/CloudContactsProvider.swift
+++ b/FlowCrypt/Functionality/Mail Provider/Contacts Provider/CloudContactsProvider.swift
@@ -61,7 +61,7 @@ extension UserContactsProvider: CloudContactsProvider {
         }
 
         return Promise<[String]> { () -> [String] in
-            let response = try await(URLSession.shared.call(URLRequest(url: url)))
+            let response = try awaitPromise(URLSession.shared.call(URLRequest(url: url)))
             let emails = try JSONDecoder().decode(GoogleContactsResponse.self, from: response.data).emails
             return emails
         }

--- a/FlowCrypt/Functionality/Mail Provider/Imap/Imap+Other.swift
+++ b/FlowCrypt/Functionality/Mail Provider/Imap/Imap+Other.swift
@@ -26,7 +26,7 @@ extension Imap {
                 return
             }
 
-            let messages = try await(self.fetchMessage(in: folder, kind: kind, uids: uids))
+            let messages = try awaitPromise(self.fetchMessage(in: folder, kind: kind, uids: uids))
             resolve(messages)
         }
     }

--- a/FlowCrypt/Functionality/Mail Provider/MessageOperations Provider/Imap+MessageOperations.swift
+++ b/FlowCrypt/Functionality/Mail Provider/MessageOperations Provider/Imap+MessageOperations.swift
@@ -52,7 +52,7 @@ extension Imap: MessageOperationsProvider {
                 return reject(ImapError.missedMessageInfo("trashPath"))
             }
 
-            try await(self.moveMsg(with: identifier, folder: folder, destFolder: trashPath))
+            try awaitPromise(self.moveMsg(with: identifier, folder: folder, destFolder: trashPath))
             resolve(())
         }
     }
@@ -80,8 +80,8 @@ extension Imap: MessageOperationsProvider {
                 return reject(ImapError.missedMessageInfo("folderPath"))
             }
 
-            try await(self.pushUpdatedMsgFlags(with: identifier, folder: folderPath, flags: MCOMessageFlag.deleted))
-            try await(self.expungeMsgs(folder: folderPath))
+            try awaitPromise(self.pushUpdatedMsgFlags(with: identifier, folder: folderPath, flags: MCOMessageFlag.deleted))
+            try awaitPromise(self.expungeMsgs(folder: folderPath))
         }
     }
 
@@ -120,7 +120,7 @@ extension Imap: MessageOperationsProvider {
                 return reject(ImapError.missedMessageInfo("intId"))
             }
 
-            try await(self.pushUpdatedMsgFlags(with: identifier, folder: folderPath, flags: MCOMessageFlag.deleted))
+            try awaitPromise(self.pushUpdatedMsgFlags(with: identifier, folder: folderPath, flags: MCOMessageFlag.deleted))
         }
     }
 }

--- a/FlowCrypt/Functionality/Mail Provider/MessagesList Provider/Gmail+MessagesList.swift
+++ b/FlowCrypt/Functionality/Mail Provider/MessagesList Provider/Gmail+MessagesList.swift
@@ -14,7 +14,7 @@ import FlowCryptCommon
 extension GmailService: MessagesListProvider {
     func fetchMessages(using context: FetchMessageContext) -> Promise<MessageContext> {
         Promise { (resolve, reject) in
-            let list = try await(fetchMessagesList(using: context))
+            let list = try awaitPromise(fetchMessagesList(using: context))
             let messageRequests: [Promise<Message>] = list.messages?.compactMap(\.identifier).map(fetchFullMessage(with:)) ?? []
 
             all(messageRequests)

--- a/FlowCrypt/Functionality/Mail Provider/MessagesList Provider/Imap+MessagesList.swift
+++ b/FlowCrypt/Functionality/Mail Provider/MessagesList Provider/Imap+MessagesList.swift
@@ -21,7 +21,7 @@ extension Imap: MessagesListProvider {
         return Promise { [weak self] resolve, reject in
             guard let self = self else { return reject(AppErr.nilSelf) }
 
-            let folderInfo = try await(self.folderInfo(for: folderPath))
+            let folderInfo = try awaitPromise(self.folderInfo(for: folderPath))
             let totalCount = Int(folderInfo.messageCount)
             if totalCount == 0 {
                 resolve(MessageContext(messages: [], pagination: .byNumber(total: totalCount)))
@@ -32,7 +32,7 @@ extension Imap: MessagesListProvider {
                 from: from ?? 0
             )
             let kind = self.messageKindProvider.imapMessagesRequestKind
-            let messages = try await(self.fetchMsgsByNumber(for: folderPath, kind: kind, set: set))
+            let messages = try awaitPromise(self.fetchMsgsByNumber(for: folderPath, kind: kind, set: set))
                 .map(Message.init)
 
             resolve(MessageContext(messages: messages, pagination: .byNumber(total: totalCount)))

--- a/FlowCrypt/Functionality/Mail Provider/SearchMessage Provider/Gmail+Search.swift
+++ b/FlowCrypt/Functionality/Mail Provider/SearchMessage Provider/Gmail+Search.swift
@@ -13,7 +13,7 @@ import GoogleAPIClientForREST
 extension GmailService: MessageSearchProvider {
     func searchExpression(using context: MessageSearchContext) -> Promise<[Message]> {
         Promise { (resolve, _) in
-            let context = try await(self.fetchMessages(using: FetchMessageContext(searchContext: context)))
+            let context = try awaitPromise(self.fetchMessages(using: FetchMessageContext(searchContext: context)))
             resolve(context.messages)
         }
     }

--- a/FlowCrypt/Functionality/Mail Provider/SearchMessage Provider/Imap+Search.swift
+++ b/FlowCrypt/Functionality/Mail Provider/SearchMessage Provider/Imap+Search.swift
@@ -27,9 +27,9 @@ extension Imap: MessageSearchProvider {
 
             let kind = self.messageKindProvider.imapMessagesRequestKind
             let path = searchContext.folderPath ?? "INBOX"
-            let indexes = try await(self.fetchUids(folder: path, expr: expression))
+            let indexes = try awaitPromise(self.fetchUids(folder: path, expr: expression))
 
-            let messages = try await(
+            let messages = try awaitPromise(
                 self.fetchMessagesByUIDOperation(
                     for: path,
                     kind: kind,

--- a/FlowCrypt/Functionality/Services/AppStartup.swift
+++ b/FlowCrypt/Functionality/Services/AppStartup.swift
@@ -34,11 +34,11 @@ struct AppStartup {
     }
 
     private func setupMigrationIfNeeded() throws {
-        try await(DataService.shared.performMigrationIfNeeded())
+        try awaitPromise(DataService.shared.performMigrationIfNeeded())
     }
 
     private func setupSession() throws {
-        try await(renewSessionIfValid())
+        try awaitPromise(renewSessionIfValid())
     }
 
     private func renewSessionIfValid() -> Promise<Void> {

--- a/FlowCrypt/Functionality/Services/AttesterApi.swift
+++ b/FlowCrypt/Functionality/Services/AttesterApi.swift
@@ -34,7 +34,7 @@ extension AttesterApi {
     func lookupEmail(email: String) -> Promise<PubkeySearchResult> {
         Promise { [weak self] () -> PubkeySearchResult in
             guard let url = self?.urlPub(emailOrLongid: email) else { throw AppErr.nilSelf }
-            let res = try await(URLSession.shared.call(url, tolerateStatus: [404]))
+            let res = try awaitPromise(URLSession.shared.call(url, tolerateStatus: [404]))
 
             if res.status >= 200, res.status <= 299 {
                 return PubkeySearchResult(email: email, armored: res.data)
@@ -67,7 +67,7 @@ extension AttesterApi {
             headers: headers
         )
         return Promise { () -> String in
-            let res = try await(URLSession.shared.call(request))
+            let res = try awaitPromise(URLSession.shared.call(request))
             return res.data.toStr()
         }
     }
@@ -80,7 +80,7 @@ extension AttesterApi {
             body: pubkey.data()
         )
         return Promise { () -> String in
-            let res = try await(URLSession.shared.call(request))
+            let res = try awaitPromise(URLSession.shared.call(request))
             return res.data.toStr()
         }
     }
@@ -94,7 +94,7 @@ extension AttesterApi {
             headers: [URLHeader(value: "application/json", httpHeaderField: "Content-Type")]
         )
         return Promise { () -> Void in
-            _ = try await(URLSession.shared.call(request)) // will throw on non-200
+            _ = try awaitPromise(URLSession.shared.call(request)) // will throw on non-200
         }
     }
 }

--- a/FlowCrypt/Functionality/Services/Backup Services/BackupService.swift
+++ b/FlowCrypt/Functionality/Services/Backup Services/BackupService.swift
@@ -35,12 +35,10 @@ struct BackupService {
 extension BackupService: BackupServiceType {
     func fetchBackups(for userId: UserId) -> Promise<[KeyDetails]> {
         Promise<[KeyDetails]> { resolve, reject in
-            let backupData = try await(self.backupProvider.searchBackups(for: userId.email))
+            let backupData = try awaitPromise(self.backupProvider.searchBackups(for: userId.email))
 
             do {
                 let parsed = try self.core.parseKeys(armoredOrBinary: backupData)
-                // TODO: - TOM 2
-                // After parsing keys there are 51 key instead of 17 attachments fetched.
                 let keys = parsed.keyDetails.filter { $0.private != nil }
                 resolve(keys)
             } catch {
@@ -76,7 +74,7 @@ extension BackupService: BackupServiceType {
                 atts: attachments
             )
             let backupEmail = try self.core.composeEmail(msg: message, fmt: .plain, pubKeys: nil)
-            try await(messageSender.sendMail(mime: backupEmail.mimeEncoded))
+            try awaitPromise(messageSender.sendMail(mime: backupEmail.mimeEncoded))
         }
     }
 

--- a/FlowCrypt/Functionality/Services/Contacts Services/RemoteContactsProvider.swift
+++ b/FlowCrypt/Functionality/Services/Contacts Services/RemoteContactsProvider.swift
@@ -29,8 +29,8 @@ struct RemoteContactsProvider {
 extension RemoteContactsProvider: ContactsProviderType {
     func searchContact(with email: String) -> Promise<Contact> {
         Promise<Contact> { resolve, _ in
-            let armoredData = try await(self.api.lookupEmail(email: email)).armored
-            let contact = try await(self.parseKey(data: armoredData, for: email))
+            let armoredData = try awaitPromise(self.api.lookupEmail(email: email)).armored
+            let contact = try awaitPromise(self.parseKey(data: armoredData, for: email))
             resolve(contact)
         }
     }

--- a/FlowCrypt/Functionality/Services/Folders Services/FoldersService.swift
+++ b/FlowCrypt/Functionality/Services/Folders Services/FoldersService.swift
@@ -50,7 +50,7 @@ final class FoldersService: FoldersServiceType {
         Promise<[FolderViewModel]> { [weak self] resolve, _ in
             guard let self = self else { throw AppErr.nilSelf }
             // fetch all folders
-            let remoteFolders = try await(self.remoteFoldersProvider.fetchFolders())
+            let remoteFolders = try awaitPromise(self.remoteFoldersProvider.fetchFolders())
 
             DispatchQueue.main.async {
                 // TODO: - ANTON - instead of removing all folders remove only

--- a/FlowCrypt/Functionality/Services/Folders Services/TrashFolderProvider.swift
+++ b/FlowCrypt/Functionality/Services/Folders Services/TrashFolderProvider.swift
@@ -28,7 +28,7 @@ extension TrashFolderProvider: TrashFolderProviderType {
         } else {
             return Promise { (resolve, _) in
                 // will get all folders
-                _ = try await(folderProvider.fetchFolders())
+                _ = try awaitPromise(folderProvider.fetchFolders())
                 resolve(localStorage.trashFolderPath)
             }
         }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -41,9 +41,9 @@ PODS:
   - PINRemoteImage/PINCache (3.0.1):
     - PINCache (~> 3.0.1)
     - PINRemoteImage/Core
-  - PromisesObjC (1.2.8)
-  - PromisesSwift (1.2.8):
-    - PromisesObjC (= 1.2.8)
+  - PromisesObjC (2.0.0)
+  - PromisesSwift (2.0.0):
+    - PromisesObjC (= 2.0.0)
   - Realm (10.7.4):
     - Realm/Headers (= 10.7.4)
   - Realm/Headers (10.7.4)
@@ -132,8 +132,8 @@ SPEC CHECKSUMS:
   PINCache: bea7c404c360f6fe0f6ee783c5cd14e778fa2aab
   PINOperation: 3a967a927e7867e61976c6cc23e5770416449fbc
   PINRemoteImage: 3b7cedb118c2d357f87e9eabc7c81ba0202cb236
-  PromisesObjC: c119f3cd559f50b7ae681fa59dc1acd19173b7e6
-  PromisesSwift: 37bad6f4daddb02f7c9c531efe91e8b21c13ee2f
+  PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58
+  PromisesSwift: e0b2a6433469efb0b83a2b84c62a2abab8e5e5d4
   Realm: f08ce1a85649a41303ecfe1cbd914c62e9e6d710
   RealmSwift: 60ec49d165f23d040ab48811d8dd177e09baf4d3
   SwiftFormat: b72e592ea0979aeee53f6052abff291181364933


### PR DESCRIPTION
Future versions of Swift reserve the word 'await'. PromisesSwift updated to version 2.0.0 where `await` replaced with `awaitPromise`