### PR TITLE
WKD public keys - for now not integrated

### DIFF
--- a/FlowCrypt.xcodeproj/project.pbxproj
+++ b/FlowCrypt.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		04B4728D1ECE29D200B8266F /* KeyInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04B4728B1ECE29D200B8266F /* KeyInfo.swift */; };
 		04B472951ECE29F600B8266F /* MyMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04B472921ECE29F600B8266F /* MyMenuViewController.swift */; };
 		04B472961ECE29F600B8266F /* SideMenuNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04B472931ECE29F600B8266F /* SideMenuNavigationController.swift */; };
+		211392A5266511E6009202EC /* PubLookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211392A4266511E6009202EC /* PubLookup.swift */; };
 		21CE25E62650070300ADFF4B /* WKDURLsConstructor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21CE25E52650070300ADFF4B /* WKDURLsConstructor.swift */; };
 		21EA3B2326565B5D00691848 /* DomainRulesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21EA3B2226565B5D00691848 /* DomainRulesTests.swift */; };
 		21EA3B2F26565B7400691848 /* domain_rules.json in Resources */ = {isa = PBXBuildFile; fileRef = 21EA3B2E26565B7400691848 /* domain_rules.json */; };
@@ -17,6 +18,7 @@
 		21EA3B3D26565B9800691848 /* domain_rules_partly_empty.json in Resources */ = {isa = PBXBuildFile; fileRef = 21EA3B3C26565B9800691848 /* domain_rules_partly_empty.json */; };
 		21EA3B532656611C00691848 /* OrganisationalRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21EA3B15265647C400691848 /* OrganisationalRule.swift */; };
 		21EA3B592656611D00691848 /* OrganisationalRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21EA3B15265647C400691848 /* OrganisationalRule.swift */; };
+		21EFF61F265A5C6700AB0B71 /* WKDURLsApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21EFF61E265A5C6700AB0B71 /* WKDURLsApi.swift */; };
 		21F836A02652A19A00B2448C /* WKDURLsConstructor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21CE25E52650070300ADFF4B /* WKDURLsConstructor.swift */; };
 		21F836B62652A26B00B2448C /* DataExntensions+ZBase32Encoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F836B52652A26B00B2448C /* DataExntensions+ZBase32Encoding.swift */; };
 		21F836CC2652A38700B2448C /* ZBase32EncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F836CB2652A38700B2448C /* ZBase32EncodingTests.swift */; };
@@ -356,12 +358,14 @@
 		069059B887A8580765029BF9 /* Pods_FlowCrypt.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FlowCrypt.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		113F04B20ECC35FC59A81A6C /* Pods-FlowCryptTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FlowCryptTests.release.xcconfig"; path = "Target Support Files/Pods-FlowCryptTests/Pods-FlowCryptTests.release.xcconfig"; sourceTree = "<group>"; };
 		11C1375F41411882DC4C9431 /* Pods-FlowCryptUIApplication.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FlowCryptUIApplication.release.xcconfig"; path = "Target Support Files/Pods-FlowCryptUIApplication/Pods-FlowCryptUIApplication.release.xcconfig"; sourceTree = "<group>"; };
+		211392A4266511E6009202EC /* PubLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PubLookup.swift; sourceTree = "<group>"; };
 		21CE25E52650070300ADFF4B /* WKDURLsConstructor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKDURLsConstructor.swift; sourceTree = "<group>"; };
 		21EA3B15265647C400691848 /* OrganisationalRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrganisationalRule.swift; sourceTree = "<group>"; };
 		21EA3B2226565B5D00691848 /* DomainRulesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainRulesTests.swift; sourceTree = "<group>"; };
 		21EA3B2E26565B7400691848 /* domain_rules.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = domain_rules.json; sourceTree = "<group>"; };
 		21EA3B3526565B8100691848 /* domain_rules_empty.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = domain_rules_empty.json; sourceTree = "<group>"; };
 		21EA3B3C26565B9800691848 /* domain_rules_partly_empty.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = domain_rules_partly_empty.json; sourceTree = "<group>"; };
+		21EFF61E265A5C6700AB0B71 /* WKDURLsApi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKDURLsApi.swift; sourceTree = "<group>"; };
 		21F836B52652A26B00B2448C /* DataExntensions+ZBase32Encoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataExntensions+ZBase32Encoding.swift"; sourceTree = "<group>"; };
 		21F836CB2652A38700B2448C /* ZBase32EncodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZBase32EncodingTests.swift; sourceTree = "<group>"; };
 		21F836D22652A46E00B2448C /* WKDURLsConstructorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKDURLsConstructorTests.swift; sourceTree = "<group>"; };
@@ -737,6 +741,7 @@
 			isa = PBXGroup;
 			children = (
 				21CE25E52650070300ADFF4B /* WKDURLsConstructor.swift */,
+				211392A4266511E6009202EC /* PubLookup.swift */,
 			);
 			path = WKDURLs;
 			sourceTree = "<group>";
@@ -907,6 +912,7 @@
 				9F31AB9F232C071700CF87EA /* GlobalRouter.swift */,
 				32DCAC088C8BFFFAF08853AC /* AttesterApi.swift */,
 				32DCAC9C0512037018F434A1 /* BackendApi.swift */,
+				21EFF61E265A5C6700AB0B71 /* WKDURLsApi.swift */,
 				D274724024F97C5C006BA6EF /* CacheService.swift */,
 				C132B9CA1EC2DE6400763715 /* GeneralConstants.swift */,
 				9FB22CFD25715DDF0026EE64 /* Key Services */,
@@ -2356,6 +2362,7 @@
 				9FB22CF025715D960026EE64 /* BackupServiceError.swift in Sources */,
 				9FBEAE5525D41BFF009E98D4 /* UserMailSessionProvider.swift in Sources */,
 				D212D36424C1AC4800035991 /* KeyId.swift in Sources */,
+				21EFF61F265A5C6700AB0B71 /* WKDURLsApi.swift in Sources */,
 				D27B911924EFE79F002DF0A1 /* LocalContactsProvider.swift in Sources */,
 				9FE1B3942563F98600D6D086 /* Imap+MessagesList.swift in Sources */,
 				32DCA04CA0DAB79C39514782 /* CoreTypes.swift in Sources */,
@@ -2364,6 +2371,7 @@
 				5A39F437239ECC23001F4607 /* KeySettingsViewController.swift in Sources */,
 				9FF0673325520DE400FCC9E6 /* GmailService+send.swift in Sources */,
 				D20D3C892520B67C00D4AA9A /* BackupOptionsViewController.swift in Sources */,
+				211392A5266511E6009202EC /* PubLookup.swift in Sources */,
 				D20D3C672520AB1000D4AA9A /* BackupViewController.swift in Sources */,
 				D2E26F6324F1698100612AF1 /* ContactsListViewController.swift in Sources */,
 				9F53CB7B2555E1E300C0157A /* GmailService+folders.swift in Sources */,

--- a/FlowCrypt.xcodeproj/project.pbxproj
+++ b/FlowCrypt.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		04B472951ECE29F600B8266F /* MyMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04B472921ECE29F600B8266F /* MyMenuViewController.swift */; };
 		04B472961ECE29F600B8266F /* SideMenuNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04B472931ECE29F600B8266F /* SideMenuNavigationController.swift */; };
 		211392A5266511E6009202EC /* PubLookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211392A4266511E6009202EC /* PubLookup.swift */; };
+		21C7DF0526697DA500C44800 /* PromiseKitExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C7DF0426697DA500C44800 /* PromiseKitExtension.swift */; };
 		21CE25E62650070300ADFF4B /* WKDURLsConstructor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21CE25E52650070300ADFF4B /* WKDURLsConstructor.swift */; };
 		21EA3B2326565B5D00691848 /* DomainRulesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21EA3B2226565B5D00691848 /* DomainRulesTests.swift */; };
 		21EA3B2F26565B7400691848 /* domain_rules.json in Resources */ = {isa = PBXBuildFile; fileRef = 21EA3B2E26565B7400691848 /* domain_rules.json */; };
@@ -359,6 +360,7 @@
 		113F04B20ECC35FC59A81A6C /* Pods-FlowCryptTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FlowCryptTests.release.xcconfig"; path = "Target Support Files/Pods-FlowCryptTests/Pods-FlowCryptTests.release.xcconfig"; sourceTree = "<group>"; };
 		11C1375F41411882DC4C9431 /* Pods-FlowCryptUIApplication.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FlowCryptUIApplication.release.xcconfig"; path = "Target Support Files/Pods-FlowCryptUIApplication/Pods-FlowCryptUIApplication.release.xcconfig"; sourceTree = "<group>"; };
 		211392A4266511E6009202EC /* PubLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PubLookup.swift; sourceTree = "<group>"; };
+		21C7DF0426697DA500C44800 /* PromiseKitExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromiseKitExtension.swift; sourceTree = "<group>"; };
 		21CE25E52650070300ADFF4B /* WKDURLsConstructor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKDURLsConstructor.swift; sourceTree = "<group>"; };
 		21EA3B15265647C400691848 /* OrganisationalRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrganisationalRule.swift; sourceTree = "<group>"; };
 		21EA3B2226565B5D00691848 /* DomainRulesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainRulesTests.swift; sourceTree = "<group>"; };
@@ -832,6 +834,7 @@
 				9FEED1B7230C08D700700F8E /* UIViewControllerExtensions.swift */,
 				9F31AB9D232BF2A600CF87EA /* UIColorExtension.swift */,
 				D2D27B78248A8694007346FA /* BigIntExtension.swift */,
+				21C7DF0426697DA500C44800 /* PromiseKitExtension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -2358,6 +2361,7 @@
 				9FE1B3802563F85400D6D086 /* MessagesListProvider.swift in Sources */,
 				32DCA1B95DDC04D671F662F8 /* URLSessionExtension.swift in Sources */,
 				D2E26F7424F2705B00612AF1 /* ContactDetailDecorator.swift in Sources */,
+				21C7DF0526697DA500C44800 /* PromiseKitExtension.swift in Sources */,
 				9FB22CD625715CA10026EE64 /* BackupServiceErrorHandler.swift in Sources */,
 				9FB22CF025715D960026EE64 /* BackupServiceError.swift in Sources */,
 				9FBEAE5525D41BFF009E98D4 /* UserMailSessionProvider.swift in Sources */,

--- a/FlowCrypt/Extensions/PromiseKitExtension.swift
+++ b/FlowCrypt/Extensions/PromiseKitExtension.swift
@@ -1,0 +1,28 @@
+//
+//  PromiseKitExtension.swift
+//  FlowCrypt
+//
+//  Created by Yevhen Kyivskyi on 04.06.2021.
+//  Copyright © 2021 FlowCrypt Limited. All rights reserved.
+//
+
+import Promises
+
+extension Promise {
+    @discardableResult
+    func recoverFromTimeOut(
+        on queue: DispatchQueue = .promises,
+        result: Value
+    ) -> Promise {
+        self.recover(on: queue) { error -> Promise in
+            if let promiseError = error as? PromiseError, promiseError == .timedOut {
+                return Promise { resolve, _ in
+                    resolve(result)
+                }
+            }
+            return Promise { _, reject in
+                reject(error)
+            }
+        }
+    }
+}

--- a/FlowCrypt/Functionality/Services/AttesterApi.swift
+++ b/FlowCrypt/Functionality/Services/AttesterApi.swift
@@ -18,6 +18,11 @@ protocol AttesterApiType {
 }
 
 final class AttesterApi: AttesterApiType {
+
+    private enum Constants {
+        static let lookupEmailRequestTimeout: TimeInterval = 10
+    }
+
     private enum Endpoint {
         static let baseURL = "https://flowcrypt.com/attester/"
     }
@@ -45,6 +50,8 @@ extension AttesterApi {
             // programming error because should never happen
             throw AppErr.unexpected("Status \(res.status) when looking up pubkey for \(email)")
         }
+        .timeout(Constants.lookupEmailRequestTimeout)
+        .recoverFromTimeOut(result: PubkeySearchResult(email: email, armored: nil))
     }
 
     @discardableResult

--- a/FlowCrypt/Functionality/Services/AttesterApi.swift
+++ b/FlowCrypt/Functionality/Services/AttesterApi.swift
@@ -51,7 +51,6 @@ extension AttesterApi {
             throw AppErr.unexpected("Status \(res.status) when looking up pubkey for \(email)")
         }
         .timeout(Constants.lookupEmailRequestTimeout)
-        .recoverFromTimeOut(result: PubkeySearchResult(email: email, armored: nil))
     }
 
     @discardableResult

--- a/FlowCrypt/Functionality/Services/WKDURLsApi.swift
+++ b/FlowCrypt/Functionality/Services/WKDURLsApi.swift
@@ -1,0 +1,129 @@
+//
+//  WKDURLsService.swift
+//  FlowCrypt
+//
+//  Created by Yevhen Kyivskyi on 23.05.2021.
+//  Copyright © 2021 FlowCrypt Limited. All rights reserved.
+//
+
+import CryptoKit
+import Promises
+
+protocol WKDURLsApiType {
+    func lookupEmail(_ email: String) -> Promise<[String]>
+    func rawLookupEmail(_ email: String) -> Promise<CoreRes.ParseKeys?>
+}
+
+class WKDURLsApi: WKDURLsApiType {
+
+    private let wkdURLsConstructor: WKDURLsConstructorType
+    private let core: Core
+
+    init(
+        wkdURLsConstructor: WKDURLsConstructorType = WKDURLsConstructor(),
+        core: Core = Core.shared
+    ) {
+        self.wkdURLsConstructor = wkdURLsConstructor
+        self.core = core
+    }
+
+    func lookupEmail(_ email: String) -> Promise<[String]> {
+        Promise<[String]> { [weak self] resolve, _ in
+            guard let self = self else { return }
+            let response = try awaitPromise(self.rawLookupEmail(email))
+            guard let safeResponse = response else {
+                resolve([])
+                return
+            }
+            let pubKeys = safeResponse.keyDetails
+                    .filter { !$0.users.filter { $0.contains(email) }.isEmpty }
+                    .map(\.public)
+            resolve(pubKeys)
+        }
+    }
+
+    func rawLookupEmail(_ email: String) -> Promise<CoreRes.ParseKeys?> {
+        guard let advancedUrlConstructorResult = wkdURLsConstructor.construct(from: email, mode: .advanced),
+              let directUrlConstructorResult = wkdURLsConstructor.construct(from: email, mode: .direct) else {
+            return Promise { resolve, _ in
+                resolve(nil)
+            }
+        }
+
+        return Promise<CoreRes.ParseKeys?> { [weak self] resolve, _ in
+            guard let self = self else { return }
+            var response: (hasPolicy: Bool, key: Data?)?
+            response = try awaitPromise(
+                self.urlLookup(
+                    advancedUrlConstructorResult.urlString,
+                    userPart: advancedUrlConstructorResult.userPart
+                )
+            )
+            if response?.hasPolicy == true && response?.key == nil {
+                resolve(nil)
+                return
+            }
+
+            if response?.key == nil {
+                response = try awaitPromise(
+                    self.urlLookup(
+                        directUrlConstructorResult.urlString,
+                        userPart: directUrlConstructorResult.userPart
+                    )
+                )
+                if response?.key == nil {
+                    resolve(nil)
+                    return
+                }
+            }
+            guard let keyData = response?.key else {
+                resolve(nil)
+                return
+            }
+            resolve(try? self.core.parseKeys(armoredOrBinary: keyData))
+        }
+    }
+}
+extension WKDURLsApi {
+
+    private func urlLookup(_ baseUrlString: String, userPart: String) -> Promise<(hasPolicy: Bool, key: Data?)> {
+
+        let policyRequest = URLRequest.urlRequest(
+            with: "\(baseUrlString)/policy",
+            method: .get,
+            body: nil
+        )
+
+        let publicKeyRequest = URLRequest.urlRequest(
+            with: "\(baseUrlString)/\(userPart)",
+            method: .get,
+            body: nil
+        )
+
+        do {
+            _ = try awaitPromise(URLSession.shared.call(policyRequest))
+        } catch {
+            Logger.nested("WKDURLsService").logInfo("Failed to load \(baseUrlString)/policy with error \(error)")
+            return Promise { resolve, _ in
+                resolve((false, nil))
+            }
+        }
+
+        do {
+            let result = try awaitPromise(URLSession.shared.call(publicKeyRequest))
+            if !result.data.toStr().isEmpty {
+                Logger.nested("WKDURLsService").logInfo("Loaded WKD url \(baseUrlString)/\(userPart) and will try to extract Public Keys")
+            }
+            return Promise { resolve, _ in
+                resolve((false, result.data))
+            }
+
+        } catch {
+            Logger.nested("WKDURLsService")
+                .logInfo("Failed to load \(baseUrlString)/\(userPart) with error \(error)")
+            return Promise { resolve, _ in
+                resolve((true, nil))
+            }
+        }
+    }
+}

--- a/FlowCrypt/Functionality/WKDURLs/PubLookup.swift
+++ b/FlowCrypt/Functionality/WKDURLs/PubLookup.swift
@@ -27,9 +27,9 @@ class PubLookup {
         self.core = core
     }
 
-    func lookupEmail(_ email: String) -> Promise<[String]> {
+    func lookupEmail(_ email: String) -> Promise<[KeyDetails]> {
 
-        return Promise<[String]> { [weak self] resolve, _ in
+        Promise<[KeyDetails]> { [weak self] resolve, _ in
             guard let self = self else {
                 resolve([])
                 return
@@ -47,7 +47,6 @@ class PubLookup {
             }
             let attesterPubKeys = attesterKeys.keyDetails
                     .filter { !$0.users.filter { $0.contains(email) }.isEmpty }
-                    .map(\.public)
             resolve(attesterPubKeys)
         }
     }

--- a/FlowCrypt/Functionality/WKDURLs/PubLookup.swift
+++ b/FlowCrypt/Functionality/WKDURLs/PubLookup.swift
@@ -1,0 +1,54 @@
+//
+//  PubLookup.swift
+//  FlowCrypt
+//
+//  Created by Yevhen Kyivskyi on 31.05.2021.
+//  Copyright © 2021 FlowCrypt Limited. All rights reserved.
+//
+
+import Promises
+
+protocol PubLookupType {
+    func lookupEmail(_ email: String) -> Promise<[String]>
+}
+
+class PubLookup {
+    private let core: Core
+    private let wkd: WKDURLsApiType
+    private let attesterApi: AttesterApiType
+
+    init(
+        wkd: WKDURLsApiType = WKDURLsApi(),
+        attesterApi: AttesterApiType = AttesterApi(),
+        core: Core = .shared
+    ) {
+        self.wkd = wkd
+        self.attesterApi = attesterApi
+        self.core = core
+    }
+
+    func lookupEmail(_ email: String) -> Promise<[String]> {
+
+        return Promise<[String]> { [weak self] resolve, _ in
+            guard let self = self else {
+                resolve([])
+                return
+            }
+            let wkdResult = try awaitPromise(self.wkd.lookupEmail(email))
+            if !wkdResult.isEmpty {
+                resolve(wkdResult)
+            }
+            let attesterResult = try awaitPromise(self.attesterApi.lookupEmail(email: email))
+            guard let armoredData = attesterResult.armored,
+                  let attesterKeys = try? self.core.parseKeys(armoredOrBinary: armoredData),
+                  !attesterKeys.keyDetails.isEmpty else {
+                resolve([])
+                return
+            }
+            let attesterPubKeys = attesterKeys.keyDetails
+                    .filter { !$0.users.filter { $0.contains(email) }.isEmpty }
+                    .map(\.public)
+            resolve(attesterPubKeys)
+        }
+    }
+}

--- a/FlowCrypt/Functionality/WKDURLs/WKDURLsConstructor.swift
+++ b/FlowCrypt/Functionality/WKDURLs/WKDURLsConstructor.swift
@@ -16,13 +16,18 @@ enum WKDURLMode {
     case advanced
 }
 
+struct WKDURLsConstructorResult {
+    let urlString: String
+    let userPart: String
+}
+
 protocol WKDURLsConstructorType {
-    func construct(from email: String, mode: WKDURLMode) -> String?
+    func construct(from email: String, mode: WKDURLMode) -> WKDURLsConstructorResult?
 }
 
 class WKDURLsConstructor: WKDURLsConstructorType {
 
-    func construct(from email: String, mode: WKDURLMode) -> String? {
+    func construct(from email: String, mode: WKDURLMode) -> WKDURLsConstructorResult? {
         let parts = email.split(separator: "@")
         if parts.count != 2 {
             return nil
@@ -30,9 +35,12 @@ class WKDURLsConstructor: WKDURLsConstructorType {
         let user = String(parts[0])
         let recipientDomain = String(parts[1]).lowercased()
         let hu = String(decoding: user.lowercased().data().SHA1.zBase32EncodedBytes(), as: Unicode.UTF8.self)
+        let userPart = "hu/\(hu)?l=\(user)"
         let directURL = "https://\(recipientDomain)/.well-known/openpgpkey/hu/\(hu)?l=\(user)"
         let advancedURL = "https://openpgpkey.\(recipientDomain)/.well-known/openpgpkey/\(recipientDomain)/hu/\(hu)?l=\(user)"
 
-        return mode == .advanced ? advancedURL : directURL
+        return mode == .advanced
+            ? WKDURLsConstructorResult(urlString: advancedURL, userPart: userPart)
+            : WKDURLsConstructorResult(urlString: directURL, userPart: userPart)
     }
 }

--- a/FlowCryptTests/Functionallity/WKDURLs/WKDURLsConstructorTests.swift
+++ b/FlowCryptTests/Functionallity/WKDURLs/WKDURLsConstructorTests.swift
@@ -23,54 +23,62 @@ class WKDURLsTests: XCTestCase {
     func test_direct_mode_lowercased_construct_URL_success() {
         let inputEmail = "recipient.hello@example.com"
         let expectedURL = "https://example.com/.well-known/openpgpkey/hu/1sbjrcaf8m3zckmmuej93nx61yn1sttg?l=recipient.hello"
+        let expectedUserPart = "hu/1sbjrcaf8m3zckmmuej93nx61yn1sttg?l=recipient.hello"
         
         let constructedURL = constructor.construct(from: inputEmail, mode: .direct)
         
-        XCTAssert(constructedURL == expectedURL)
+        XCTAssert(constructedURL?.urlString == expectedURL)
+        XCTAssert(constructedURL?.userPart == expectedUserPart)
     }
     
     func test_advanced_mode_lowercased_construct_URL_success() {
         let inputEmail = "recipient.hello@example.com"
         let expectedURL = "https://openpgpkey.example.com/.well-known/openpgpkey/example.com/hu/1sbjrcaf8m3zckmmuej93nx61yn1sttg?l=recipient.hello"
+        let expectedUserPart = "hu/1sbjrcaf8m3zckmmuej93nx61yn1sttg?l=recipient.hello"
         
         let constructedURL = constructor.construct(from: inputEmail, mode: .advanced)
         
-        XCTAssert(constructedURL == expectedURL)
+        XCTAssert(constructedURL?.urlString == expectedURL)
+        XCTAssert(constructedURL?.userPart == expectedUserPart)
     }
     
     func test_direct_mode_uppercased_construct_URL_success() {
         let inputEmail = "UPPER@EXAMPLE.COM"
         let expectedURL = "https://example.com/.well-known/openpgpkey/hu/awhcnhf7a4ax8qha5u1rwymkfaswmjz8?l=UPPER"
+        let expectedUserPart = "hu/awhcnhf7a4ax8qha5u1rwymkfaswmjz8?l=UPPER"
         
         let constructedURL = constructor.construct(from: inputEmail, mode: .direct)
         
-        XCTAssert(constructedURL == expectedURL)
+        XCTAssert(constructedURL?.urlString == expectedURL)
+        XCTAssert(constructedURL?.userPart == expectedUserPart)
     }
     
     func test_advanced_mode_uppercased_construct_URL_success() {
         let inputEmail = "UPPER@EXAMPLE.COM"
         let expectedURL = "https://openpgpkey.example.com/.well-known/openpgpkey/example.com/hu/awhcnhf7a4ax8qha5u1rwymkfaswmjz8?l=UPPER"
+        let expectedUserPart = "hu/awhcnhf7a4ax8qha5u1rwymkfaswmjz8?l=UPPER"
         
         let constructedURL = constructor.construct(from: inputEmail, mode: .advanced)
         
-        XCTAssert(constructedURL == expectedURL)
+        XCTAssert(constructedURL?.urlString == expectedURL)
+        XCTAssert(constructedURL?.userPart == expectedUserPart)
     }
     
     func test_construct_URL_failure() {
         var inputEmail = "examplemail.com"
-        var constructedURL = constructor.construct(from: inputEmail, mode: .advanced)
+        var constructedURL = constructor.construct(from: inputEmail, mode: .advanced)?.urlString
         
         XCTAssertNil(constructedURL)
         
         inputEmail = "example@"
         
-        constructedURL = constructor.construct(from: inputEmail, mode: .advanced)
+        constructedURL = constructor.construct(from: inputEmail, mode: .advanced)?.urlString
         
         XCTAssertNil(constructedURL)
         
         inputEmail = "@mail.com"
         
-        constructedURL = constructor.construct(from: inputEmail, mode: .advanced)
+        constructedURL = constructor.construct(from: inputEmail, mode: .advanced)?.urlString
         
         XCTAssertNil(constructedURL)
     }


### PR DESCRIPTION
This PR implements logic for retrieving wkd or attester public keys;

issue #296

----------------------------------

**Tests**:
- Tests updated for WKDURLsConstructor
- Can't add tests for WKDURLsApi and AttesterApi because there is no networking entity that injects into these classes and could be spied. 
P.S. It would be great to refactor Networking call `URLSession.shared.call(_ urlRequest: URLRequest, tolerateStatus: [Int]? = nil) -> Promise<HttpRes>` for separate networking entity to test classes that make API calls.

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
