### PR TITLE
Prepwork for retrieving client config from FES

### DIFF
--- a/FlowCrypt.xcodeproj/project.pbxproj
+++ b/FlowCrypt.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		21C7DEFC26669A3700C44800 /* CalendarExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C7DEFB26669A3700C44800 /* CalendarExtension.swift */; };
 		21C7DEFE26669CE100C44800 /* DateFormattingExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F56BD3723438C7000A7371A /* DateFormattingExtensions.swift */; };
 		21C7DF0526697DA500C44800 /* PromiseKitExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C7DF0426697DA500C44800 /* PromiseKitExtension.swift */; };
+		21C7DF09266C0D8F00C44800 /* EnterpriseServerApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C7DF08266C0D8F00C44800 /* EnterpriseServerApi.swift */; };
+		21C7DF0B266C0E3600C44800 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C7DF0A266C0E3600C44800 /* Configuration.swift */; };
 		21CE25E62650070300ADFF4B /* WKDURLsConstructor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21CE25E52650070300ADFF4B /* WKDURLsConstructor.swift */; };
 		21EA3B2326565B5D00691848 /* DomainRulesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21EA3B2226565B5D00691848 /* DomainRulesTests.swift */; };
 		21EA3B2F26565B7400691848 /* domain_rules.json in Resources */ = {isa = PBXBuildFile; fileRef = 21EA3B2E26565B7400691848 /* domain_rules.json */; };
@@ -362,6 +364,8 @@
 		211392A4266511E6009202EC /* PubLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PubLookup.swift; sourceTree = "<group>"; };
 		21C7DEFB26669A3700C44800 /* CalendarExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarExtension.swift; sourceTree = "<group>"; };
 		21C7DF0426697DA500C44800 /* PromiseKitExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromiseKitExtension.swift; sourceTree = "<group>"; };
+		21C7DF08266C0D8F00C44800 /* EnterpriseServerApi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnterpriseServerApi.swift; sourceTree = "<group>"; };
+		21C7DF0A266C0E3600C44800 /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
 		21CE25E52650070300ADFF4B /* WKDURLsConstructor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKDURLsConstructor.swift; sourceTree = "<group>"; };
 		21EA3B15265647C400691848 /* OrganisationalRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrganisationalRule.swift; sourceTree = "<group>"; };
 		21EA3B2226565B5D00691848 /* DomainRulesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainRulesTests.swift; sourceTree = "<group>"; };
@@ -915,6 +919,7 @@
 				9F31AB9F232C071700CF87EA /* GlobalRouter.swift */,
 				32DCAC088C8BFFFAF08853AC /* AttesterApi.swift */,
 				32DCAC9C0512037018F434A1 /* BackendApi.swift */,
+				21C7DF08266C0D8F00C44800 /* EnterpriseServerApi.swift */,
 				21EFF61E265A5C6700AB0B71 /* WKDURLsApi.swift */,
 				D274724024F97C5C006BA6EF /* CacheService.swift */,
 				C132B9CA1EC2DE6400763715 /* GeneralConstants.swift */,
@@ -1101,6 +1106,7 @@
 				9FDF3653235A218E00614596 /* main.swift */,
 				9FDF3655235A22DA00614596 /* AppReset.swift */,
 				9F8220D426336626004B2009 /* Logger.swift */,
+				21C7DF0A266C0E3600C44800 /* Configuration.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -2398,6 +2404,7 @@
 				9F8220D526336626004B2009 /* Logger.swift in Sources */,
 				32DCA557DA4EF81A74CEF951 /* TestData.swift in Sources */,
 				9F0C3C1A231819C500299985 /* MessageKindProviderType.swift in Sources */,
+				21C7DF09266C0D8F00C44800 /* EnterpriseServerApi.swift in Sources */,
 				9FF0670825520CF800FCC9E6 /* GmailService.swift in Sources */,
 				9F5C2A77257D705100DE9B4B /* MessageLabel.swift in Sources */,
 				9F93623F2573D16F0009912F /* Gmail+Message.swift in Sources */,
@@ -2428,6 +2435,7 @@
 				D2FF6966243115EC007182F0 /* EmailProviderViewController.swift in Sources */,
 				D2CDC3D22402D4DA002B045F /* UIViewControllerExtensions.swift in Sources */,
 				D297990D2444A76D004A3E31 /* UserObject+Empty.swift in Sources */,
+				21C7DF0B266C0E3600C44800 /* Configuration.swift in Sources */,
 				D2D27B79248A8694007346FA /* BigIntExtension.swift in Sources */,
 				9F003D6D25EA8F3200EB38C0 /* UserAccountService.swift in Sources */,
 				D29AFFF92409767F00C1387D /* GoogleContactsResponse.swift in Sources */,

--- a/FlowCrypt/App/Configuration.swift
+++ b/FlowCrypt/App/Configuration.swift
@@ -9,5 +9,5 @@
 import Foundation
 
 class Configuration {
-    static let excludedDomains = ["gmail.com", "googlemail.com", "outlook.com"]
+    static let publicEmailProviderDomains = ["gmail.com", "googlemail.com", "outlook.com"]
 }

--- a/FlowCrypt/App/Configuration.swift
+++ b/FlowCrypt/App/Configuration.swift
@@ -1,0 +1,13 @@
+//
+//  Configuration.swift
+//  FlowCrypt
+//
+//  Created by Yevhen Kyivskyi on 05.06.2021.
+//  Copyright © 2021 FlowCrypt Limited. All rights reserved.
+//
+
+import Foundation
+
+class Configuration {
+    static let excludedDomains = ["gmail.com", "googlemail.com", "outlook.com"]
+}

--- a/FlowCrypt/Core/Core.swift
+++ b/FlowCrypt/Core/Core.swift
@@ -44,7 +44,7 @@ final class Core {
 
     public func parseDecryptMsg(encrypted: Data, keys: [PrvKeyInfo], msgPwd: String?, isEmail: Bool) throws -> CoreRes.ParseDecryptMsg {
         let json: [String : Any?]? = [
-            "keys": try keys.map { try $0.toDict() },
+            "keys": try keys.map { try $0.toJsonEncodedDict() },
             "isEmail": isEmail,
             "msgPwd": msgPwd
         ]
@@ -91,7 +91,7 @@ final class Core {
     }
 
     public func generateKey(passphrase: String, variant: KeyVariant, userIds: [UserId]) throws -> CoreRes.GenerateKey {
-        let request: [String: Any] = ["passphrase": passphrase, "variant": String(variant.rawValue), "userIds": try userIds.map { try $0.toDict() }]
+        let request: [String: Any] = ["passphrase": passphrase, "variant": String(variant.rawValue), "userIds": try userIds.map { try $0.toJsonEncodedDict() }]
         let r = try call("generateKey", jsonDict: request, data: nil)
         return try r.json.decodeJson(as: CoreRes.GenerateKey.self)
     }

--- a/FlowCrypt/Functionality/Services/EnterpriseServerApi.swift
+++ b/FlowCrypt/Functionality/Services/EnterpriseServerApi.swift
@@ -30,7 +30,7 @@ class EnterpriseServerApi: EnterpriseServerApiType {
             }
             let urlString = "https://fes.\(userDomain)/"
             let request = URLRequest.urlRequest(
-                with: "\(urlString)api/fdsfsdf",
+                with: "\(urlString)api/",
                 method: .get,
                 body: nil
             )

--- a/FlowCrypt/Functionality/Services/EnterpriseServerApi.swift
+++ b/FlowCrypt/Functionality/Services/EnterpriseServerApi.swift
@@ -24,20 +24,20 @@ class EnterpriseServerApi: EnterpriseServerApiType {
     func getActiveFesUrl(for email: String) -> Promise<String?> {
         Promise<String?> { resolve, _ in
             guard let userDomain = email.recipientDomain,
-                  !Configuration.excludedDomains.contains(userDomain) else {
+                  !Configuration.publicEmailProviderDomains.contains(userDomain) else {
                 resolve(nil)
                 return
             }
             let urlString = "https://fes.\(userDomain)/"
             let request = URLRequest.urlRequest(
-                with: "\(urlString)api/",
+                with: "\(urlString)api/fdsfsdf",
                 method: .get,
                 body: nil
             )
 
-            let response = try awaitPromise(URLSession.shared.call(request, tolerateStatus: [404]))
-            guard response.status != 404,
-                  let responseDictionary = try? response.data.toDict(),
+            let response = try? awaitPromise(URLSession.shared.call(request))
+            guard let safeReponse = response,
+                  let responseDictionary = try? safeReponse.data.toDict(),
                   let service = responseDictionary[Constants.serviceKey] as? String,
                   service == Constants.serviceNeededValue else {
                 resolve(nil)

--- a/FlowCrypt/Functionality/Services/EnterpriseServerApi.swift
+++ b/FlowCrypt/Functionality/Services/EnterpriseServerApi.swift
@@ -1,0 +1,52 @@
+//
+//  EnterpriseServerApi.swift
+//  FlowCrypt
+//
+//  Created by Yevhen Kyivskyi on 05.06.2021.
+//  Copyright © 2021 FlowCrypt Limited. All rights reserved.
+//
+
+import Promises
+
+protocol EnterpriseServerApiType {
+    func getActiveFesUrl(for email: String) -> Promise<String?>
+}
+
+class EnterpriseServerApi: EnterpriseServerApiType {
+
+    private enum Constants {
+        static let getActiveFesTimeout: TimeInterval = 4
+
+        static let serviceKey = "service"
+        static let serviceNeededValue = "enterprise-server"
+    }
+
+    func getActiveFesUrl(for email: String) -> Promise<String?> {
+        Promise<String?> { resolve, _ in
+            guard let userDomain = email.recipientDomain,
+                  !Configuration.excludedDomains.contains(userDomain) else {
+                resolve(nil)
+                return
+            }
+            let urlString = "https://fes.\(userDomain)/"
+            let request = URLRequest.urlRequest(
+                with: "\(urlString)api/",
+                method: .get,
+                body: nil
+            )
+
+            let response = try awaitPromise(URLSession.shared.call(request, tolerateStatus: [404]))
+            guard response.status != 404,
+                  let responseDictionary = try? response.data.toDict(),
+                  let service = responseDictionary[Constants.serviceKey] as? String,
+                  service == Constants.serviceNeededValue else {
+                resolve(nil)
+                return
+            }
+
+            resolve(urlString)
+        }
+        .timeout(Constants.getActiveFesTimeout)
+        .recoverFromTimeOut(result: nil)
+    }
+}

--- a/FlowCrypt/Functionality/Services/WKDURLsApi.swift
+++ b/FlowCrypt/Functionality/Services/WKDURLsApi.swift
@@ -22,8 +22,6 @@ class WKDURLsApi: WKDURLsApiType {
     private let wkdURLsConstructor: WKDURLsConstructorType
     private let core: Core
 
-    private let excludedDomains = ["gmail.com", "googlemail.com"]
-
     init(
         wkdURLsConstructor: WKDURLsConstructorType = WKDURLsConstructor(),
         core: Core = Core.shared
@@ -49,7 +47,7 @@ class WKDURLsApi: WKDURLsApiType {
     }
 
     func rawLookupEmail(_ email: String) -> Promise<CoreRes.ParseKeys?> {
-        guard !excludedDomains.contains(email.recipientDomain ?? ""),
+        guard !Configuration.publicEmailProviderDomains.contains(email.recipientDomain ?? ""),
               let advancedUrlConstructorResult = wkdURLsConstructor.construct(from: email, mode: .advanced),
               let directUrlConstructorResult = wkdURLsConstructor.construct(from: email, mode: .direct)
                else {

--- a/FlowCryptCommon/Extensions/CodableExntensions.swift
+++ b/FlowCryptCommon/Extensions/CodableExntensions.swift
@@ -9,7 +9,7 @@ public extension Encodable {
         try JSONEncoder().encode(self)
     }
 
-    func toDict() throws -> [String: Any] {
+    func toJsonEncodedDict() throws -> [String: Any] {
         let data = try JSONEncoder().encode(self)
         guard let dictionary = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any] else {
             throw NSError()

--- a/FlowCryptCommon/Extensions/Data/DataExtensions.swift
+++ b/FlowCryptCommon/Extensions/Data/DataExtensions.swift
@@ -12,6 +12,13 @@ public extension Data {
     func toStr() -> String {
         String(decoding: self, as: UTF8.self)
     }
+    
+    func toDict() throws -> [String: Any] {
+        guard let dictionary = try JSONSerialization.jsonObject(with: self, options: .allowFragments) as? [String: Any] else {
+            throw NSError()
+        }
+        return dictionary
+    }
 }
 
 extension String {


### PR DESCRIPTION
This PR adds service to retrieve FES url configuration

issue #339

----------------------------------

**Tests** :
- Difficult to test because we have no separate layer for networking that could be "spied"

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
