### PR TITLE
Updated image: flowcrypt/flowcrypt-email-server to 0.0.5

### DIFF
--- a/docker-mailserver/config/postfix-accounts.cf
+++ b/docker-mailserver/config/postfix-accounts.cf
@@ -4,3 +4,6 @@ android@flowcrypt.test|{SHA512-CRYPT}$6$eomPqpSbwWqZ6URr$JCOTb7wejmo6qm/FZsWtm8g
 denbond7@flowcrypt.test|{SHA512-CRYPT}$6$sz55seBQvRDFVVqo$d1lDvSuUWHklikoCQmPpmBukN2vSl47JWe1f6f1rxSV4UVurdPgvKEr2kwG6ICPF26bFqWlMmFBM7AZc/8PwK.
 user_with_more_than_21_letters@flowcrypt.test|{SHA512-CRYPT}$6$L2k5lesNInE0wri5$usr0RhSnqll1UUGAph/hVbXTZq/UlgOW1BHlC8AWDUctMAfT2b.dmQ78wlh2EWStf.vhtYZbdmN5MjW4R3/hp0
 user_without_letters@flowcrypt.test|{SHA512-CRYPT}$6$j99fwRGw0hCIw2Vm$GjKW6ErUV40NwVY64/nYvDcLjhpGqkpoX/o1UhZVoaNtxyPmdXO4j/KVbTnHThqgVa4X/EipLKrD1L5vmrvnU/
+single_backup@flowcrypt.test|{SHA512-CRYPT}$6$ZG/we/7ue.Bn3c3d$FAXzClXcd1cU77xmwjBvJQFtldmzLfLyNe2uLSuExo8MpHKIdcg8fxSEQuFG3/8hsexGSUQCwTy/tFPkJtoGM/
+no_backups@flowcrypt.test|{SHA512-CRYPT}$6$xlZI4EzbrOz8Kg/Z$FbmV.72iNX.hM1jfYEfr7tHhGK6aalXdzJzwjODnf42Tq71OkMWDldVkPGXNaUDnpiDIU6aQU2tjXHgH.lOPT/
+has_msgs_no_backups@flowcrypt.test|{SHA512-CRYPT}$6$i72HHZU2/S08yUgA$1.jK0Newz32HVZueRFGq7mkidWqNb8nN3Bv7havb8tiSLfrzGZPzGbbG16m4zisLXHpoUB2LkWSOD6ll6GXwp.

--- a/docker-mailserver/docker-compose.yml
+++ b/docker-mailserver/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   mail:
-    image: flowcrypt/flowcrypt-email-server:0.0.4
+    image: flowcrypt/flowcrypt-email-server:0.0.5
     hostname: ${HOSTNAME}
     domainname: ${DOMAINNAME}
     container_name: ${CONTAINER_NAME}


### PR DESCRIPTION
This PR updated email server settings to use a docker image with `tag == 0.0.5`
close #467

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
