### PR TITLE
Add UI Tests - no key, settings, folders, wrong creds

### DIFF
--- a/FlowCrypt/Controllers/SetupImap/SetupImapViewController.swift
+++ b/FlowCrypt/Controllers/SetupImap/SetupImapViewController.swift
@@ -520,9 +520,7 @@ extension SetupImapViewController {
     }
 
     private func handleConnection(error: Error) {
-        showAlert(error: error, message: "Connection Error") { [weak self] in
-            self?.globalRouter.signOut()
-        }
+        showAlert(error: error, message: "Connection Error")
     }
 
     private func handleSuccessfulConnection() {

--- a/FlowCrypt/Functionality/Mail Provider/MessagesList Provider/Model/MessageLabel.swift
+++ b/FlowCrypt/Functionality/Mail Provider/MessagesList Provider/Model/MessageLabel.swift
@@ -83,7 +83,7 @@ extension MessageLabelType {
         case .label("submited"): return MCOMessageFlag.submitted.rawValue
         case .none: return 0
         default:
-            assertionFailure("This label \(self) is not supported by this provider")
+            debugPrint("This label \(self) is not supported by this provider")
             return 0
         }
     }

--- a/FlowCryptUITests/Resources/UserCredentials.swift
+++ b/FlowCryptUITests/Resources/UserCredentials.swift
@@ -10,7 +10,7 @@ import Foundation
 
 struct UserCredentials: Codable, Equatable {
     let email: String
-    let password: String
+    var password: String
     let pass: String
     let recovery: String
     let privateKey: String
@@ -32,6 +32,9 @@ struct UserCredentials: Codable, Equatable {
     /// has_msgs_no_backups@flowcrypt.test
     /// user with messages but without any backups
     static let imapHasMessagesNoBackups = UserCredentials.user(with: "has_msgs_no_backups@flowcrypt.test")
+
+    /// denbond7@flowcrypt
+    static let imapDenBond = UserCredentials.user(with: "denbond7@flowcrypt.test")
 }
 
 extension UserCredentials {

--- a/FlowCryptUITests/SignInImapTest.swift
+++ b/FlowCryptUITests/SignInImapTest.swift
@@ -42,7 +42,7 @@ class SignInImapTest: XCTestCase, AppTest {
     }
 
     // restart app -> loads inbox
-    func test_2_restart_app_load_inbox() {
+    func test_2_restart_load_inbox() {
         let application = XCUIApplication()
         wait(2)
         application.buttons["+"].tap()
@@ -74,7 +74,7 @@ class SignInImapTest: XCTestCase, AppTest {
     }
 
     // restart app -> loads inbox -> verify messages
-    func test_3_restart_app_contains_emails() {
+    func test_3_restart_contains_emails() {
         let app = XCUIApplication()
 
         let tablesQuery = app.tables
@@ -189,8 +189,187 @@ class SignInImapTest: XCTestCase, AppTest {
         navigationBackButton.tap()
     }
 
+    // restart app -> verify folders
+    func test_5_restart_folders() {
+        let app = XCUIApplication()
+        let tablesQuery = app.tables
+
+        let menuButton = app.navigationBars["Inbox"].buttons["menu icn"]
+        menuButton.tap()
+        wait(1)
+        tablesQuery.cells.otherElements.containing(.staticText, identifier:"...").staticTexts["denbond7@flowcrypt.test"].tap()
+        menuButton.tap()
+
+        tablesQuery.staticTexts["Junk"].tap()
+        tablesQuery.staticTexts["Junk is empty"].tap()
+        app.navigationBars["Junk"].buttons["menu icn"].tap()
+
+        tablesQuery.staticTexts["Drafts"].tap()
+        tablesQuery.staticTexts["Drafts is empty"].tap()
+        app.navigationBars["Drafts"].buttons["menu icn"].tap()
+
+        tablesQuery.staticTexts["Trash"].tap()
+        tablesQuery.staticTexts["Standard message - plaintext"].tap()
+        navigationBackButton.tap()
+        app.navigationBars["Trash"].buttons["menu icn"].tap()
+
+        tablesQuery.staticTexts["Sent"].tap()
+        tablesQuery.staticTexts["Sent is empty"].tap()
+        app.navigationBars["Sent"].buttons["menu icn"].tap()
+
+        tablesQuery.staticTexts["Inbox"].tap()
+        menuButton.tap()
+    }
+
+    // restart app -> verify settings
+    func test_6_restart_settings() {
+        let app = XCUIApplication()
+        let tablesQuery = app.tables
+
+        menuButton.tap()
+        wait(1)
+
+        tablesQuery.staticTexts["Settings"].tap()
+        tablesQuery.staticTexts["Backups"].tap()
+        navigationBackButton.tap()
+        tablesQuery.staticTexts["Security and Privacy"].tap()
+        tablesQuery.staticTexts["Contacts"].tap()
+
+        app.navigationBars["Contacts"].staticTexts["Contacts"].tap()
+        navigationBackButton.tap()
+
+        tablesQuery.staticTexts["Keys"].tap()
+        wait(1)
+        tablesQuery.cells.firstMatch.tap()
+        tablesQuery.buttons["Show public key"].tap()
+
+        // part of public key
+        let searchText = "nxjMEYIq7phYJKwYBBAHaRw8BAQdAat45rrh"
+        let predicate = NSPredicate(format: "label CONTAINS[c] %@", searchText)
+        tablesQuery.containing(predicate)
+
+        navigationBackButton.tap()
+
+        tablesQuery.buttons["Show key details"].tap()
+        tablesQuery.staticTexts["Longid: 225F8023C20D0957"].tap()
+        tablesQuery.staticTexts["Longid: 4F1458BD22B7BB53"].tap()
+
+        navigationBackButton.tap()
+        tablesQuery.buttons["Copy to clipboard"].tap()
+        tablesQuery.buttons["Share"].tap()
+        app.navigationBars["UIActivityContentView"].buttons["Close"].tap()
+        tablesQuery.buttons["Show private key"].tap()
+
+        navigationBackButton.tap()
+
+        app.navigationBars["Keys"].buttons["Add"].tap()
+        XCTAssert(tablesQuery.buttons["Load From File"].exists)
+        navigationBackButton.tap()
+        navigationBackButton.tap()
+
+        tablesQuery.staticTexts["Notifications"].tap()
+        tablesQuery.staticTexts["Legal"].tap()
+
+        let collectionViewsQuery = app.collectionViews
+        collectionViewsQuery.staticTexts["Terms"].tap()
+        collectionViewsQuery.staticTexts["License"].tap()
+        collectionViewsQuery.staticTexts["Sources"].tap()
+        app.navigationBars["Legal"].buttons["arrow left c"].tap()
+        tablesQuery.staticTexts["Experimental"].tap()
+    }
+
+    // restart app -> Try to send message to user without pub key
+    func test_7_restart_send_message_no_pub_key() {
+        let application = XCUIApplication()
+        application.buttons["+"].tap()
+
+        wait(0.3)
+
+        application.typeText("test@test.com")
+        app.navigationBars["Inbox"].buttons["android send"].tap()
+
+        let errorAlert = app.alerts["Error"].scrollViews.otherElements
+        XCTAssert(errorAlert.staticTexts["Could not compose message\n\nEnter subject"].exists)
+        errorAlert.buttons["OK"].tap()
+
+        application.tables.textFields["Subject"].tap()
+        wait(1)
+        application.tables.textFields["Subject"].tap()
+        app.typeText("Subject")
+        app.navigationBars["Inbox"].buttons["android send"].tap()
+
+        let errorMessage = application.alerts["Error"].scrollViews.otherElements
+        XCTAssert(errorAlert.staticTexts["Could not compose message\n\nEnter secure message"].exists)
+        errorMessage.buttons["OK"].tap()
+
+        let cell = app.tables.children(matching: .cell).element(boundBy: 5)
+        cell.tap()
+        app.typeText("Message")
+        app.navigationBars["Inbox"].buttons["android send"].tap()
+
+        XCTAssert(errorAlert.staticTexts["Could not compose message\n\nRecipient doesn't seem to have encryption set up"].exists)
+        wait(1)
+    }
+
+    // restart app -> verify contacts functionality
+    func test_9_restart_app_contacts() {
+//         let application = XCUIApplication()
+//         let tablesQuery = application.tables
+//         app.buttons["+"].tap()
+//         app.typeText(UserCredentials.imapDev.email)
+//         goKeyboardButton.tap()
+//         wait(2)
+//
+//         tablesQuery.textFields["Add Recipient"].tap()
+//         wait(1)
+//         app.typeText(UserCredentials.imapDenBond.email)
+//         wait(1)
+//         goKeyboardButton.tap()
+//         wait(1)
+//
+//         navigationBackButton.tap()
+//
+//         application.navigationBars["Inbox"].buttons["menu icn"].tap()
+//         tablesQuery.staticTexts["Settings"].tap()
+//         tablesQuery.staticTexts["Contacts"].tap()
+//
+//         // open first contacts
+//         let app = XCUIApplication()
+//         let contactsQuery = app.tables
+//         contactsQuery.staticTexts["default@flowcrypt.test"].tap()
+//         XCTAssert(contactsQuery.staticTexts["default@flowcrypt.test"].exists)
+//         XCTAssert(contactsQuery.staticTexts["225F8023C20D0957,\n4F1458BD22B7BB53"].exists)
+//         XCTAssert(contactsQuery.staticTexts["3DEBE9F677D5B9BB38E5A244225F8023C20D0957,\nF81D1B0FDEE37AA32B8F0CD04F1458BD22B7BB53"].exists)
+//         XCTAssert(contactsQuery.staticTexts["eddsa"].exists)
+//         application.navigationBars["Public Key"].buttons["arrow left c"].tap()
+//
+//         // open next contact
+//         contactsQuery.staticTexts["denbond7@flowcrypt.test"].tap()
+//         XCTAssert(contactsQuery.staticTexts["default@flowcrypt.test"].exists)
+//         XCTAssert(contactsQuery.staticTexts["C32089CD6AF8D6CE,\nD7A3DEDB65CB1EFB"].exists)
+//         XCTAssert(contactsQuery.staticTexts["Apr 30, 2021 at 8:57:44 AM"].exists)
+//         XCTAssert(contactsQuery.staticTexts["eddsa"].exists)
+     }
+
+    // try to sign in with wrong credentials
+    func test_9_sign_in_with_wrong_credentials() {
+        var user = UserCredentials.imapDev
+        user.password = "123"
+        loginWithImap(user)
+
+        let errorAlert = app.alerts["Error"].scrollViews.otherElements
+
+        // part of public key
+        let searchText = "Connection Error"
+        let predicate = NSPredicate(format: "label CONTAINS[c] %@", searchText)
+        errorAlert.staticTexts.containing(predicate)
+        errorAlert.buttons["OK"].tap()
+
+        XCTAssert(app.tables.buttons["Connect"].exists)
+    }
+
     // login -> cancel
-    func test_5_login_cancel() {
+    func test_10_login_cancel() {
         let user = UserCredentials.imapDev
         loginWithImap(user)
 
@@ -199,17 +378,16 @@ class SignInImapTest: XCTestCase, AppTest {
     }
 
     // login with user without key backups and emails
-    // login -> no messages
-    func test_6_login_no_messages() {
+    func test_11_login_no_messages() {
         verifyFlowWithNoBackups(for: .imapDen)
     }
 
-    func test_7_has_msgs_no_backups() {
+    func test_12_has_msgs_no_backups() {
         verifyFlowWithNoBackups(for: .imapHasMessagesNoBackups)
     }
 
     // login with wrong pass phrase
-    func test_8_login_bad_pass_phrase() {
+    func test_13_login_bad_pass_phrase() {
         let user = UserCredentials.imapDev
         loginWithImap(user)
 
@@ -473,13 +651,3 @@ extension SignInImapTest {
 ////        XCTAssert(app.tables.staticTexts[user.email].exists, "Wrong recipient in sent message")
 ////        XCTAssert(app.tables.staticTexts["Some Subject"].exists, "Wrong subject")
 //    }
-//
-//    // send new msg -> no pubkey
-//    func test_11_send_message_no_pub_key() {
-//        wait(2)
-//        sendMessage(to: "flowcrypt.nopubkey@gmail.com")
-//        wait(3)
-//        let errorAlert = app.alerts["Error"]
-//        XCTAssert(errorAlert.exists)
-//    }
-//}


### PR DESCRIPTION
This PR adds UI tests described in
#486 
#481
close #485

----------------------------------

**Tests**:
* UI Tests - Check send message functionality to user without key.
* UI Tests - Verify that we can't send message without subject and entered message.
* UI Tests - Settings and folders functionality

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
