### PR TITLE
issue #508 return core response directly instead of encoding - TypeScript parts

### DIFF
--- a/Core/source/entrypoint-bare.ts
+++ b/Core/source/entrypoint-bare.ts
@@ -21,7 +21,7 @@ global.handleRequestFromHost = (endpointName: string, request: string, data: str
       cb(formatBareOutput(fmtErr(new Error(`Unknown endpoint: ${endpointName}`))));
     } else {
       handler(JSON.parse(request), [Buf.fromBase64Str(data)])
-        .then(res => cb(formatBareOutput(Buf.concat(res))))
+        .then(res => cb(formatBareOutput(Buf.fromUtfStr(JSON.stringify(res)))))
         .catch(err => cb(formatBareOutput(fmtErr(err))));
     }
   } catch (err) {

--- a/Core/source/entrypoint-bare.ts
+++ b/Core/source/entrypoint-bare.ts
@@ -6,25 +6,23 @@
 
 import { Buf } from './core/buf';
 import { Endpoints } from './mobile-interface/endpoints';
-import { fmtErr } from './mobile-interface/format-output';
+import { EndpointRes, fmtErr } from './mobile-interface/format-output';
 
 declare const global: any;
 
 const endpoints = new Endpoints();
 
-const formatBareOutput = (res: Buf) => res.toBase64Str();
-
-global.handleRequestFromHost = (endpointName: string, request: string, data: string, cb: (b64response: string) => void): void => {
+global.handleRequestFromHost = (endpointName: string, request: string, data: string, cb: (response: EndpointRes) => void): void => {
   try {
     const handler = endpoints[endpointName];
     if (!handler) {
-      cb(formatBareOutput(fmtErr(new Error(`Unknown endpoint: ${endpointName}`))));
+      cb(fmtErr(new Error(`Unknown endpoint: ${endpointName}`)));
     } else {
       handler(JSON.parse(request), [Buf.fromBase64Str(data)])
-        .then(res => cb(formatBareOutput(Buf.fromUtfStr(JSON.stringify(res)))))
-        .catch(err => cb(formatBareOutput(fmtErr(err))));
+        .then(res => cb(res))
+        .catch(err => cb(fmtErr(err)));
     }
   } catch (err) {
-    cb(formatBareOutput(fmtErr(err)));
+    cb(fmtErr(err));
   }
 };

--- a/Core/source/mobile-interface/endpoints.ts
+++ b/Core/source/mobile-interface/endpoints.ts
@@ -195,7 +195,7 @@ export class Endpoints {
     return fmtRes({ success: true, name: decryptedMeta.filename || '' }, decryptedMeta.content);
   }
 
-  public parseDateStr = async (uncheckedReq: any) => {
+  public parseDateStr = async (uncheckedReq: any): Promise<EndpointRes> => {
     const { dateStr } = ValidateInput.parseDateStr(uncheckedReq);
     return fmtRes({ timestamp: String(Date.parse(dateStr) || -1) });
   }

--- a/Core/source/mobile-interface/format-output.ts
+++ b/Core/source/mobile-interface/format-output.ts
@@ -125,13 +125,13 @@ export const fmtRes = (response: {}, data?: Buf | Uint8Array): EndpointRes => {
 }
 
 export const fmtErr = (e: any): Buf => {
-  const r = fmtRes({
+  const res = fmtRes({
     error: {
       message: String(e),
       stack: e && typeof e === 'object' ? e.stack || '' : ''
     }
   });
-  return Buf.fromUtfStr(r.json);
+  return Buf.fromUtfStr(res.json);
 }
 
 export const printReplayTestDefinition = (endpoint: string, request: {}, data: Buf) => {

--- a/Core/source/mobile-interface/format-output.ts
+++ b/Core/source/mobile-interface/format-output.ts
@@ -124,14 +124,13 @@ export const fmtRes = (response: {}, data?: Buf | Uint8Array): EndpointRes => {
   };
 }
 
-export const fmtErr = (e: any): Buf => {
-  const res = fmtRes({
+export const fmtErr = (e: any): EndpointRes => {
+  return fmtRes({
     error: {
       message: String(e),
       stack: e && typeof e === 'object' ? e.stack || '' : ''
     }
   });
-  return Buf.fromUtfStr(res.json);
 }
 
 export const printReplayTestDefinition = (endpoint: string, request: {}, data: Buf) => {

--- a/Core/source/mobile-interface/format-output.ts
+++ b/Core/source/mobile-interface/format-output.ts
@@ -10,6 +10,7 @@ import { Str } from '../core/common';
 import { Xss } from '../platform/xss';
 
 export type Buffers = (Buf | Uint8Array)[];
+export type EndpointRes = {json: string, data: Buf | Uint8Array};
 
 export const isContentBlock = (t: MsgBlockType) => t === 'plainText' || t === 'decryptedText' || t === 'plainHtml' || t === 'decryptedHtml' || t === 'signedMsg' || t === 'verifiedMsg';
 
@@ -116,22 +117,22 @@ export const fmtContentBlock = (allContentBlocks: MsgBlock[]): { contentBlock: M
   return { contentBlock: MsgBlock.fromContent('plainHtml', msgContentAsHtml), text: msgContentAsText.trim() };
 }
 
-export const fmtRes = (response: {}, data?: Buf | Uint8Array): Buffers => {
-  const buffers: Buffers = [];
-  buffers.push(Buf.fromUtfStr(JSON.stringify(response)));
-  buffers.push(Buf.fromUtfStr('\n'));
-  if (data) {
-    buffers.push(data);
-  }
-  return buffers;
+export const fmtRes = (response: {}, data?: Buf | Uint8Array): EndpointRes => {
+  return {
+    json: JSON.stringify(response),
+    data: data || new Uint8Array(0)
+  };
 }
 
-export const fmtErr = (e: any): Buf => Buf.concat(fmtRes({
-  error: {
-    message: String(e),
-    stack: e && typeof e === 'object' ? e.stack || '' : ''
-  }
-}));
+export const fmtErr = (e: any): Buf => {
+  const r = fmtRes({
+    error: {
+      message: String(e),
+      stack: e && typeof e === 'object' ? e.stack || '' : ''
+    }
+  });
+  return Buf.fromUtfStr(r.json);
+}
 
 export const printReplayTestDefinition = (endpoint: string, request: {}, data: Buf) => {
   console.log(`

--- a/Core/source/test.ts
+++ b/Core/source/test.ts
@@ -10,7 +10,7 @@ global.dereq_html_sanitize = require("sanitize-html");
 
 import * as ava from 'ava';
 
-import { allKeypairNames, expectData, expectEmptyJson, expectEmptyUint8Array, expectNoData, getCompatAsset, getHtmlAsset, getKeypairs, parseResponse } from './test/test-utils';
+import { allKeypairNames, expectData, expectEmptyJson, expectEmptyUint8Array, expectEmptyUint8Array, getCompatAsset, getHtmlAsset, getKeypairs, parseResponse } from './test/test-utils';
 
 import { Xss } from './platform/xss';
 import { expect } from 'chai';
@@ -31,14 +31,14 @@ ava.default('version', async t => {
 });
 
 ava.default('generateKey', async t => {
-  const { _json, data } = await endpoints.generateKey({ variant: 'curve25519', passphrase: 'riruekfhydekdmdbsyd', userIds: [{ email: 'a@b.com', name: 'Him' }] });
+  const { json: _json, data } = await endpoints.generateKey({ variant: 'curve25519', passphrase: 'riruekfhydekdmdbsyd', userIds: [{ email: 'a@b.com', name: 'Him' }] });
   const json = JSON.parse(_json);
   expect(json.key.private).to.contain('-----BEGIN PGP PRIVATE KEY BLOCK-----');
   expect(json.key.public).to.contain('-----BEGIN PGP PUBLIC KEY BLOCK-----');
   expect(json.key.isFullyEncrypted).to.be.true;
   expect(json.key.isFullyDecrypted).to.be.false;
   expect(json.key.algo).to.deep.equal({ algorithm: 'eddsa', curve: 'ed25519', algorithmId: 22 });
-  expectNoData(data);
+  expectEmptyUint8Array(data);
   t.pass();
 });
 
@@ -265,28 +265,28 @@ for (const keypairName of allKeypairNames.filter(name => name != 'expired')) {
 ava.default('parseDateStr', async t => {
   const { data, json } = parseResponse(await endpoints.parseDateStr({ dateStr: 'Sun, 10 Feb 2019 07:08:20 -0800' }));
   expect(json).to.deep.equal({ timestamp: '1549811300000' });
-  expectNoData(data);
+  expectEmptyUint8Array(data);
   t.pass();
 });
 
 ava.default('gmailBackupSearch', async t => {
   const { data, json } = parseResponse(await endpoints.gmailBackupSearch({ acctEmail: 'test@acct.com' }));
   expect(json).to.deep.equal({ query: 'from:test@acct.com to:test@acct.com (subject:"Your FlowCrypt Backup" OR subject: "Your CryptUp Backup" OR subject: "All you need to know about CryptUP (contains a backup)" OR subject: "CryptUP Account Backup") -is:spam' });
-  expectNoData(data);
+  expectEmptyUint8Array(data);
   t.pass();
 });
 
 ava.default('isEmailValid - true', async t => {
   const { data, json } = parseResponse(await endpoints.isEmailValid({ email: 'test@acct.com' }));
   expect(json).to.deep.equal({ valid: true });
-  expectNoData(data);
+  expectEmptyUint8Array(data);
   t.pass();
 });
 
 ava.default('isEmailValid - false', async t => {
   const { data, json } = parseResponse(await endpoints.isEmailValid({ email: 'testacct.com' }));
   expect(json).to.deep.equal({ valid: false });
-  expectNoData(data);
+  expectEmptyUint8Array(data);
   t.pass();
 });
 
@@ -315,7 +315,7 @@ ava.default('parseKeys', async t => {
       }
     ]
   });
-  expectNoData(data);
+  expectEmptyUint8Array(data);
   t.pass();
 });
 
@@ -355,7 +355,7 @@ ava.default('parseKeys - expiration and date last updated', async t => {
       }
     ]
   });
-  expectNoData(data);
+  expectEmptyUint8Array(data);
   t.pass();
 });
 
@@ -365,7 +365,7 @@ ava.default('decryptKey', async t => {
   const { keys: [decryptedKey] } = await openpgp.key.readArmored(json.decryptedKey);
   expect(decryptedKey.isFullyDecrypted()).to.be.true;
   expect(decryptedKey.isFullyEncrypted()).to.be.false;
-  expectNoData(data);
+  expectEmptyUint8Array(data);
   t.pass();
 });
 
@@ -377,7 +377,7 @@ ava.default('encryptKey', async t => {
   expect(encryptedKey.isFullyEncrypted()).to.be.true;
   expect(encryptedKey.isFullyDecrypted()).to.be.false;
   expect(await encryptedKey.decrypt(passphrase)).to.be.true;
-  expectNoData(data);
+  expectEmptyUint8Array(data);
   t.pass();
 });
 
@@ -443,7 +443,7 @@ ava.default('parseDecryptMsg compat mime-email-encrypted-inline-pgpmime', async 
 
 ava.default('zxcvbnStrengthBar', async t => {
   const { data, json } = parseResponse(await endpoints.zxcvbnStrengthBar({ guesses: 88946283684265, purpose: 'passphrase' }));
-  expectNoData(data);
+  expectEmptyUint8Array(data);
   expect(json).to.deep.equal({
     word: {
       match: 'week',

--- a/Core/source/test.ts
+++ b/Core/source/test.ts
@@ -10,7 +10,7 @@ global.dereq_html_sanitize = require("sanitize-html");
 
 import * as ava from 'ava';
 
-import { allKeypairNames, expectData, expectEmptyJson, expectEmptyUint8Array, expectEmptyUint8Array, getCompatAsset, getHtmlAsset, getKeypairs, parseResponse } from './test/test-utils';
+import { allKeypairNames, expectData, expectEmptyJson, expectNoData, getCompatAsset, getHtmlAsset, getKeypairs, parseResponse } from './test/test-utils';
 
 import { Xss } from './platform/xss';
 import { expect } from 'chai';
@@ -24,9 +24,9 @@ const htmlSpecialChars = Xss.escape(textSpecialChars).replace('\n', '<br />');
 const endpoints = new Endpoints();
 
 ava.default('version', async t => {
-  const { json, data } = await endpoints.version();
+  const { json, data } = parseResponse(await endpoints.version());
   expect(json).to.have.property('app_version');
-  expectEmptyUint8Array(data);
+  expectNoData(data);
   t.pass();
 });
 
@@ -38,7 +38,7 @@ ava.default('generateKey', async t => {
   expect(json.key.isFullyEncrypted).to.be.true;
   expect(json.key.isFullyDecrypted).to.be.false;
   expect(json.key.algo).to.deep.equal({ algorithm: 'eddsa', curve: 'ed25519', algorithmId: 22 });
-  expectEmptyUint8Array(data);
+  expectNoData(data);
   t.pass();
 });
 
@@ -265,28 +265,28 @@ for (const keypairName of allKeypairNames.filter(name => name != 'expired')) {
 ava.default('parseDateStr', async t => {
   const { data, json } = parseResponse(await endpoints.parseDateStr({ dateStr: 'Sun, 10 Feb 2019 07:08:20 -0800' }));
   expect(json).to.deep.equal({ timestamp: '1549811300000' });
-  expectEmptyUint8Array(data);
+  expectNoData(data);
   t.pass();
 });
 
 ava.default('gmailBackupSearch', async t => {
   const { data, json } = parseResponse(await endpoints.gmailBackupSearch({ acctEmail: 'test@acct.com' }));
   expect(json).to.deep.equal({ query: 'from:test@acct.com to:test@acct.com (subject:"Your FlowCrypt Backup" OR subject: "Your CryptUp Backup" OR subject: "All you need to know about CryptUP (contains a backup)" OR subject: "CryptUP Account Backup") -is:spam' });
-  expectEmptyUint8Array(data);
+  expectNoData(data);
   t.pass();
 });
 
 ava.default('isEmailValid - true', async t => {
   const { data, json } = parseResponse(await endpoints.isEmailValid({ email: 'test@acct.com' }));
   expect(json).to.deep.equal({ valid: true });
-  expectEmptyUint8Array(data);
+  expectNoData(data);
   t.pass();
 });
 
 ava.default('isEmailValid - false', async t => {
   const { data, json } = parseResponse(await endpoints.isEmailValid({ email: 'testacct.com' }));
   expect(json).to.deep.equal({ valid: false });
-  expectEmptyUint8Array(data);
+  expectNoData(data);
   t.pass();
 });
 
@@ -315,7 +315,7 @@ ava.default('parseKeys', async t => {
       }
     ]
   });
-  expectEmptyUint8Array(data);
+  expectNoData(data);
   t.pass();
 });
 
@@ -355,7 +355,7 @@ ava.default('parseKeys - expiration and date last updated', async t => {
       }
     ]
   });
-  expectEmptyUint8Array(data);
+  expectNoData(data);
   t.pass();
 });
 
@@ -365,7 +365,7 @@ ava.default('decryptKey', async t => {
   const { keys: [decryptedKey] } = await openpgp.key.readArmored(json.decryptedKey);
   expect(decryptedKey.isFullyDecrypted()).to.be.true;
   expect(decryptedKey.isFullyEncrypted()).to.be.false;
-  expectEmptyUint8Array(data);
+  expectNoData(data);
   t.pass();
 });
 
@@ -377,7 +377,7 @@ ava.default('encryptKey', async t => {
   expect(encryptedKey.isFullyEncrypted()).to.be.true;
   expect(encryptedKey.isFullyDecrypted()).to.be.false;
   expect(await encryptedKey.decrypt(passphrase)).to.be.true;
-  expectEmptyUint8Array(data);
+  expectNoData(data);
   t.pass();
 });
 
@@ -443,7 +443,7 @@ ava.default('parseDecryptMsg compat mime-email-encrypted-inline-pgpmime', async 
 
 ava.default('zxcvbnStrengthBar', async t => {
   const { data, json } = parseResponse(await endpoints.zxcvbnStrengthBar({ guesses: 88946283684265, purpose: 'passphrase' }));
-  expectEmptyUint8Array(data);
+  expectNoData(data);
   expect(json).to.deep.equal({
     word: {
       match: 'week',

--- a/Core/source/test.ts
+++ b/Core/source/test.ts
@@ -31,7 +31,7 @@ ava.default('version', async t => {
 });
 
 ava.default('generateKey', async t => {
-  const { json: json, data } = parseResponse(await endpoints.generateKey({ variant: 'curve25519', passphrase: 'riruekfhydekdmdbsyd', userIds: [{ email: 'a@b.com', name: 'Him' }] }));
+  const { json, data } = parseResponse(await endpoints.generateKey({ variant: 'curve25519', passphrase: 'riruekfhydekdmdbsyd', userIds: [{ email: 'a@b.com', name: 'Him' }] }));
   expect(json.key.private).to.contain('-----BEGIN PGP PRIVATE KEY BLOCK-----');
   expect(json.key.public).to.contain('-----BEGIN PGP PUBLIC KEY BLOCK-----');
   expect(json.key.isFullyEncrypted).to.be.true;

--- a/Core/source/test.ts
+++ b/Core/source/test.ts
@@ -10,7 +10,7 @@ global.dereq_html_sanitize = require("sanitize-html");
 
 import * as ava from 'ava';
 
-import { allKeypairNames, expectData, expectEmptyJson, expectNoData, getCompatAsset, getHtmlAsset, getKeypairs, parseResponse } from './test/test-utils';
+import { allKeypairNames, expectData, expectEmptyJson, expectEmptyUint8Array, expectNoData, getCompatAsset, getHtmlAsset, getKeypairs, parseResponse } from './test/test-utils';
 
 import { Xss } from './platform/xss';
 import { expect } from 'chai';
@@ -24,14 +24,15 @@ const htmlSpecialChars = Xss.escape(textSpecialChars).replace('\n', '<br />');
 const endpoints = new Endpoints();
 
 ava.default('version', async t => {
-  const { json, data } = parseResponse(await endpoints.version());
+  const { json, data } = await endpoints.version();
   expect(json).to.have.property('app_version');
-  expectNoData(data);
+  expectEmptyUint8Array(data);
   t.pass();
 });
 
 ava.default('generateKey', async t => {
-  const { json, data } = parseResponse(await endpoints.generateKey({ variant: 'curve25519', passphrase: 'riruekfhydekdmdbsyd', userIds: [{ email: 'a@b.com', name: 'Him' }] }));
+  const { _json, data } = await endpoints.generateKey({ variant: 'curve25519', passphrase: 'riruekfhydekdmdbsyd', userIds: [{ email: 'a@b.com', name: 'Him' }] });
+  const json = JSON.parse(_json);
   expect(json.key.private).to.contain('-----BEGIN PGP PRIVATE KEY BLOCK-----');
   expect(json.key.public).to.contain('-----BEGIN PGP PUBLIC KEY BLOCK-----');
   expect(json.key.isFullyEncrypted).to.be.true;

--- a/Core/source/test.ts
+++ b/Core/source/test.ts
@@ -31,8 +31,7 @@ ava.default('version', async t => {
 });
 
 ava.default('generateKey', async t => {
-  const { json: _json, data } = await endpoints.generateKey({ variant: 'curve25519', passphrase: 'riruekfhydekdmdbsyd', userIds: [{ email: 'a@b.com', name: 'Him' }] });
-  const json = JSON.parse(_json);
+  const { json: json, data } = parseResponse(await endpoints.generateKey({ variant: 'curve25519', passphrase: 'riruekfhydekdmdbsyd', userIds: [{ email: 'a@b.com', name: 'Him' }] }));
   expect(json.key.private).to.contain('-----BEGIN PGP PRIVATE KEY BLOCK-----');
   expect(json.key.public).to.contain('-----BEGIN PGP PUBLIC KEY BLOCK-----');
   expect(json.key.isFullyEncrypted).to.be.true;

--- a/Core/source/test/test-utils.ts
+++ b/Core/source/test/test-utils.ts
@@ -7,26 +7,15 @@ import * as https from 'https';
 import * as fs from 'fs';
 import { config, expect } from 'chai';
 import { Buf } from '../core/buf';
-import { Buffers } from '../mobile-interface/format-output';
+import { EndpointRes } from '../mobile-interface/format-output';
 config.truncateThreshold = 0
 
 export type AvaContext = ava.ExecutionContext<any>;
 type JsonDict = { [k: string]: any };
 type TestKey = { pubKey: string, private: string, decrypted: string, passphrase: string, longid: string };
 
-export const parseResponse = (buffers: Buffers) => {
-  const everything = Buffer.concat(buffers);
-  const newlineIndex = everything.indexOf('\n');
-  if (newlineIndex === -1) {
-    console.log('everything', everything);
-    console.log('everything', everything.toString());
-    throw new Error(`could not find newline in response data`);
-  }
-  const jsonLine = everything.slice(0, newlineIndex).toString();
-  const json = JSON.parse(jsonLine);
-  const data = everything.slice(newlineIndex + 1);
-  const err = json.error ? json.error.message : undefined;
-  return { json, data, err };
+export const parseResponse = (response: EndpointRes) => {
+  return { json: JSON.parse(response.json), data: response.data };
 }
 
 export const httpGet = async (url: string): Promise<Buf> => {
@@ -53,17 +42,14 @@ export const expectEmptyJson = (json: JsonDict) => {
   expect(Object.keys(json)).to.have.property('length').that.equals(0);
 }
 
-export const expectNoData = (data: Buffer) => {
-  expect(data).to.be.instanceof(Buffer);
+export const expectNoData = (data: Uint8Array) => {
+  expect(data).to.be.instanceof(Uint8Array);
   expect(data).to.have.property('length').that.equals(0);
 }
 
-export const expectEmptyUint8Array = (data: Uint8Array) => {
-  expect(data).to.have.property('length').that.equals(0);
-}
-
-export const expectData = (data: Buffer, type?: 'armoredMsg' | 'msgBlocks' | 'binary', details?: any[] | Buffer) => {
-  expect(data).to.be.instanceof(Buffer);
+export const expectData = (_data: Uint8Array, type?: 'armoredMsg' | 'msgBlocks' | 'binary', details?: any[] | Buffer) => {
+  expect(_data).to.be.instanceof(Uint8Array);
+  const data = Buffer.from(_data);
   expect(data).to.have.property('length').that.does.not.equal(0);
   const dataStr = data.toString();
   if (type === 'armoredMsg') {

--- a/Core/source/test/test-utils.ts
+++ b/Core/source/test/test-utils.ts
@@ -58,6 +58,10 @@ export const expectNoData = (data: Buffer) => {
   expect(data).to.have.property('length').that.equals(0);
 }
 
+export const expectEmptyUint8Array = (data: Uint8Array) => {
+  expect(data).to.have.property('length').that.equals(0);
+}
+
 export const expectData = (data: Buffer, type?: 'armoredMsg' | 'msgBlocks' | 'binary', details?: any[] | Buffer) => {
   expect(data).to.be.instanceof(Buffer);
   expect(data).to.have.property('length').that.does.not.equal(0);


### PR DESCRIPTION
This PR changes format of the TS Core response. 

issue #508 - only the typescript part without rebuilding js and Swift

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
