### PR TITLE
issue #426 make decryptedKey not nullable

### DIFF
--- a/FlowCrypt/Core/CoreTypes.swift
+++ b/FlowCrypt/Core/CoreTypes.swift
@@ -37,7 +37,7 @@ struct CoreRes {
     }
 
     struct DecryptKey: Decodable {
-        let decryptedKey: String?
+        let decryptedKey: String
     }
 
     struct EncryptKey: Decodable {

--- a/FlowCrypt/Functionality/Pgp/KeyMethods.swift
+++ b/FlowCrypt/Functionality/Pgp/KeyMethods.swift
@@ -35,17 +35,13 @@ final class KeyMethods: KeyMethodsType {
                 return nil
             }
 
-            guard let decrypted = try? self.decrypter.decryptKey(armoredPrv: privateKey, passphrase: passPhrase) else {
+            do {
+                _ = try self.decrypter.decryptKey(armoredPrv: privateKey, passphrase: passPhrase)
+                return key
+            } catch {
                 logger.logInfo("Filtered not decrypted key")
                 return nil
             }
-
-            guard decrypted.decryptedKey != nil else {
-                logger.logInfo("Filtered. decryptedKey = nil for key \(key.primaryFingerprint)")
-                return nil
-            }
-
-            return key
         }
     }
 }

--- a/FlowCryptAppTests/Core/FlowCryptCoreTests.swift
+++ b/FlowCryptAppTests/Core/FlowCryptCoreTests.swift
@@ -78,14 +78,13 @@ class FlowCryptCoreTests: XCTestCase {
         let decryptKeyRes = try core.decryptKey(armoredPrv: TestData.k0.prv, passphrase: TestData.k0.passphrase)
         XCTAssertNotNil(decryptKeyRes.decryptedKey)
         // make sure indeed decrypted
-        let parseKeyRes = try core.parseKeys(armoredOrBinary: decryptKeyRes.decryptedKey!.data(using: .utf8)!)
+        let parseKeyRes = try core.parseKeys(armoredOrBinary: decryptKeyRes.decryptedKey.data(using: .utf8)!)
         XCTAssertEqual(parseKeyRes.keyDetails[0].isFullyDecrypted, true)
         XCTAssertEqual(parseKeyRes.keyDetails[0].isFullyEncrypted, false)
     }
 
-    func testDecryptKeyWithWrongPassPhrase() throws {
-        let k = try core.decryptKey(armoredPrv: TestData.k0.prv, passphrase: "wrong")
-        XCTAssertNil(k.decryptedKey)
+    func testDecryptKeyWithWrongPassPhrase() {
+        XCTAssertThrowsError(try core.decryptKey(armoredPrv: TestData.k0.prv, passphrase: "wrong"))
     }
 
     func testComposeEmailPlain() throws {

--- a/FlowCryptAppTests/Functionallity/PGP/KeyMethodsTest.swift
+++ b/FlowCryptAppTests/Functionallity/PGP/KeyMethodsTest.swift
@@ -66,12 +66,6 @@ class KeyMethodsTest: XCTestCase {
         XCTAssertTrue(result.isEmpty)
     }
     
-    func testNoDecryptedKey() {
-        decrypter.result = .success(CoreRes.DecryptKey(decryptedKey: nil))
-        let result = sut.filterByPassPhraseMatch(keys: validKeys, passPhrase: passPhrase)
-        XCTAssertTrue(result.isEmpty)
-    }
-    
     func testSuccessDecryption() {
         decrypter.result = .success(CoreRes.DecryptKey(decryptedKey: "some key"))
         let result = sut.filterByPassPhraseMatch(keys: validKeys, passPhrase: passPhrase)


### PR DESCRIPTION
This PR makes `decryptedKey` property of `DecryptKey` not nullable.

close #426  // if this PR closes an issue

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated - deleted `testNoDecryptedKey` test (as `decryptedKey` can't be `nil` now), updated `testDecryptKeyWithWrongPassPhrase` and `testDecryptKeyWithWrongPassPhrase` tests to handle updated `decryptedKey` property

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
