### PR TITLE
Wrong attachment size check on compose message

### DIFF
--- a/FlowCrypt/Controllers/Compose/ComposeViewController.swift
+++ b/FlowCrypt/Controllers/Compose/ComposeViewController.swift
@@ -686,7 +686,7 @@ extension ComposeViewController: UIImagePickerControllerDelegate, UINavigationCo
     }
 
     private func appendAttachmentIfAllowed(_ attachment: ComposeMessageAttachment) {
-        let totalSize = contextToSend.attachments.reduce(0, { $0 + $1.size })
+        let totalSize = contextToSend.attachments.reduce(0, { $0 + $1.size }) + attachment.size
         if totalSize > GeneralConstants.Global.attachmentSizeLimit {
             showToast("files_picking_size_error_message".localized)
         } else {


### PR DESCRIPTION
This PR fixes attachment size checking on Compose view
close #550

----------------------------------

**Tests** :
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
