### PR TITLE
Bugfix/issue 516 keys fetch

### DIFF
--- a/FlowCryptAppTests/ExtensionTests.swift
+++ b/FlowCryptAppTests/ExtensionTests.swift
@@ -63,6 +63,14 @@ extension ExtensionTests {
 
         XCTAssertNotNil(collection?[safe: 0])
     }
+
+    func test_unique() {
+        let collection = [1, 2, 2, 3, 4, 4]
+        let uniqueCollection = collection.unique()
+
+        XCTAssertEqual(uniqueCollection, [1, 2, 3, 4])
+        XCTAssertEqual(uniqueCollection.unique(), uniqueCollection)
+    }
 }
 
 // MARK: - Calendar

--- a/FlowCryptCommon/Extensions/CollectionExtensions.swift
+++ b/FlowCryptCommon/Extensions/CollectionExtensions.swift
@@ -53,6 +53,7 @@ public extension Array where Element == String {
 
 public extension Collection where Element: Hashable {
     func unique() -> [Element] {
-        return Array(Set(self))
+        var seen: Set<Element> = []
+        return filter { seen.insert($0).inserted }
     }
 }


### PR DESCRIPTION
This PR fixes "fetch keys" error for accounts with EKM set up.

close #516

----------------------------------

**Tests**:
- Tests added - this issue was caused by `unique()` function which sometimes changed array order. I added `test_unique` test for validating array order

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
