### PR TITLE
issue #440 stop logging sensitive information

### DIFF
--- a/FlowCrypt/Controllers/Setup/SetupCreatePassphraseAbstractViewController.swift
+++ b/FlowCrypt/Controllers/Setup/SetupCreatePassphraseAbstractViewController.swift
@@ -189,7 +189,7 @@ extension SetupCreatePassphraseAbstractViewController {
             showAlert(message: "setup_wrong_pass_phrase_retry".localized)
             return
         }
-        logger.logInfo("Setup account with \(passPhrase)")
+        logger.logInfo("Setup account with passphrase")
         setupAccount(with: passPhrase)
     }
 }

--- a/FlowCrypt/Functionality/DataManager/Encrypted Storage/KeyChainService.swift
+++ b/FlowCrypt/Functionality/DataManager/Encrypted Storage/KeyChainService.swift
@@ -36,7 +36,7 @@ struct KeyChainService: KeyChainServiceType {
             .base64EncodedString()
             .replacingOccurrences(of: "[^A-Za-z0-9]+", with: "", options: [.regularExpression])
 
-        logger.logInfo("LocalStorage.secureKeychainPrefix generating new: \(prefix)")
+        logger.logInfo("LocalStorage.secureKeychainPrefix generating new prefix")
         UserDefaults.standard.set(prefix, forKey: prefixStorageIndex)
         return prefix + storageEncryptionKeyIndexSuffix
     }()

--- a/FlowCrypt/Functionality/Services/Key Services/PassPhraseService.swift
+++ b/FlowCrypt/Functionality/Services/Key Services/PassPhraseService.swift
@@ -73,10 +73,10 @@ final class PassPhraseService: PassPhraseServiceType {
 
     func savePassPhrase(with passPhrase: PassPhrase, inStorage: Bool) {
         if inStorage {
-            logger.logInfo("Save to storage \(passPhrase.primaryFingerprint)")
+            logger.logInfo("Save passphrase to storage")
             encryptedStorage.save(passPhrase: passPhrase)
         } else {
-            logger.logInfo("Save in memory \(passPhrase.primaryFingerprint)")
+            logger.logInfo("Save passphrase in memory")
 
             inMemoryStorage.save(passPhrase: passPhrase)
 


### PR DESCRIPTION
This PR removes sensitive information from logs. I noticed only passphrases printed to logs, please let me know if you'll notice other important information in logs.

issue #440  - edited tom, oauth ID tokens left
----------------------------------

**Tests**:
- Does not need tests

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
