### PR TITLE
Use a byte array instead of b64string for Core request data

### DIFF
--- a/Core/source/entrypoint-bare.ts
+++ b/Core/source/entrypoint-bare.ts
@@ -4,7 +4,6 @@
 
 'use strict';
 
-import { Buf } from './core/buf';
 import { Endpoints } from './mobile-interface/endpoints';
 import { EndpointRes, fmtErr } from './mobile-interface/format-output';
 
@@ -12,13 +11,13 @@ declare const global: any;
 
 const endpoints = new Endpoints();
 
-global.handleRequestFromHost = (endpointName: string, request: string, data: string, cb: (response: EndpointRes) => void): void => {
+global.handleRequestFromHost = (endpointName: string, request: string, data: Uint8Array, cb: (response: EndpointRes) => void): void => {
   try {
     const handler = endpoints[endpointName];
     if (!handler) {
       cb(fmtErr(new Error(`Unknown endpoint: ${endpointName}`)));
     } else {
-      handler(JSON.parse(request), [Buf.fromBase64Str(data)])
+      handler(JSON.parse(request), [data])
         .then(res => cb(res))
         .catch(err => cb(fmtErr(err)));
     }

--- a/FlowCrypt/Core/Core.swift
+++ b/FlowCrypt/Core/Core.swift
@@ -212,7 +212,7 @@ final class Core: KeyDecrypter, CoreComposeMessageType {
     private func call(_ endpoint: String, jsonData: Data, data: Data) throws -> RawRes {
         try blockUntilReadyOrThrow()
         cb_last_value = nil
-        jsEndpointListener!.call(withArguments: [endpoint, String(data: jsonData, encoding: .utf8)!, data.base64EncodedString(), cb_catcher!])
+        jsEndpointListener!.call(withArguments: [endpoint, String(data: jsonData, encoding: .utf8)!, Array<UInt8>(data), cb_catcher!])
         guard
             let resJsonData = cb_last_value?.0.data(using: .utf8),
             let rawResponse = cb_last_value?.1


### PR DESCRIPTION
close #545

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
