### PR TITLE
[code ok] Disallow attester organisational rule

### DIFF
--- a/FlowCrypt/Models/OrganisationalRule.swift
+++ b/FlowCrypt/Models/OrganisationalRule.swift
@@ -120,8 +120,17 @@ class OrganisationalRules {
 
     /// Some orgs have a list of email domains where they do NOT want such emails to be looked up on public sources (such as Attester)
     /// This is because they already have other means to obtain public keys for these domains, such as from their own internal keyserver
-    func canLookupThisRecipientOnAttester(recipient email: String) -> Bool {
-        !(clientConfiguration.disallowAttesterSearchForDomains ?? []).contains(email.recipientDomain ?? "")
+    func canLookupThisRecipientOnAttester(recipient email: String) throws -> Bool {
+        let disallowedDomains = clientConfiguration.disallowAttesterSearchForDomains ?? []
+
+        if disallowedDomains.contains("*") {
+            return false
+        }
+
+        guard let recipientDomain = email.recipientDomain else {
+            throw AppErr.general("organisational_wrong_email_error".localizeWithArguments(email))
+        }
+        return !disallowedDomains.contains(recipientDomain)
     }
 
     /// Some orgs use flows that are only implemented in POST /initial/legacy_submit and not in POST /pub/email@corp.co:

--- a/FlowCrypt/Resources/en.lproj/Localizable.strings
+++ b/FlowCrypt/Resources/en.lproj/Localizable.strings
@@ -214,6 +214,7 @@
 "organisational_rules_ekm_private_keys_message" = "Ignoring %d keys returned by EKM %@ (not implemented)";
 "organisational_rules_ekm_empty_private_keys_error" = "There are no private keys configured for you. Please ask yout systems administrator or help desk";
 "organisational_rules_ekm_keys_are_not_decrypted_error" = "Received private keys are not fully decrypted. Please try login flow again";
+"organisational_wrong_email_error" = "Not a valid email %@";
 
 // Email key manager api error
 "emai_keymanager_api_no_google_id_token_error_description" = "There is no Google ID token were found while getting client configuration";


### PR DESCRIPTION

This PR updates canLookupThisRecipientOnAttester OrgRule, ignores attester api depending on canLookupThisRecipientOnAttester

close #299

----------------------------------

**Tests**:
- Difficult to test

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
