### PR TITLE
Bugfix/issue 587 logout passphrases

### DIFF
--- a/FlowCrypt/Functionality/DataManager/Local Storage/LocalStorage.swift
+++ b/FlowCrypt/Functionality/DataManager/Local Storage/LocalStorage.swift
@@ -23,9 +23,12 @@ struct LocalStorage: LocalStorageType {
     }
 
     let storage: UserDefaults
+    let passPhraseStorage: PassPhraseStorageType & LogOutHandler
 
-    init(storage: UserDefaults = .standard) {
+    init(storage: UserDefaults = .standard,
+         passPhraseStorage: PassPhraseStorageType & LogOutHandler = InMemoryPassPhraseStorage()) {
         self.storage = storage
+        self.passPhraseStorage = passPhraseStorage
     }
 }
 
@@ -40,6 +43,7 @@ extension LocalStorage {
 
 extension LocalStorage: LogOutHandler {
     func logOutUser(email: String) throws {
+        try passPhraseStorage.logOutUser(email: email)
         // For now we store only trash folder path in user defaults
         // see no reason to add logic for removing data for a concrete user
         cleanup()

--- a/FlowCrypt/Functionality/Services/Key Services/InMemoryPassPhraseStorage.swift
+++ b/FlowCrypt/Functionality/Services/Key Services/InMemoryPassPhraseStorage.swift
@@ -35,7 +35,7 @@ final class InMemoryPassPhraseStorage: PassPhraseStorageType {
     }
 
     func remove(passPhrase: PassPhrase) {
-        passPhraseProvider.removePassPhrases(with: passPhrase)
+        passPhraseProvider.remove(passPhrases: [passPhrase])
     }
 
     func getPassPhrases() -> [PassPhrase] {
@@ -65,12 +65,18 @@ final class InMemoryPassPhraseStorage: PassPhraseStorageType {
     }
 }
 
+extension InMemoryPassPhraseStorage: LogOutHandler {
+    func logOutUser(email: String) throws {
+        passPhraseProvider.remove(passPhrases: passPhraseProvider.passPhrases)
+    }
+}
+
 // MARK: - Convenience
 
 protocol InMemoryPassPhraseProviderType {
     var passPhrases: Set<PassPhrase> { get }
     func save(passPhrase: PassPhrase)
-    func removePassPhrases(with objects: PassPhrase)
+    func remove(passPhrases: Set<PassPhrase>)
 }
 
 /// - Warning: - should be shared instance
@@ -86,9 +92,7 @@ final class InMemoryPassPhraseProvider: InMemoryPassPhraseProviderType {
         passPhrases.insert(passPhrase)
     }
 
-    func removePassPhrases(with objects: PassPhrase) {
-        if passPhrases.contains(objects) {
-            passPhrases.remove(objects)
-        }
+    func remove(passPhrases passPhrasesToDelete: Set<PassPhrase>) {
+        passPhrasesToDelete.forEach { passPhrases.remove($0) }
     }
 }

--- a/FlowCryptAppTests/Functionality/Services/PassPhraseStorageTests/InMemoryPassPhraseStorageTest.swift
+++ b/FlowCryptAppTests/Functionality/Services/PassPhraseStorageTests/InMemoryPassPhraseStorageTest.swift
@@ -74,9 +74,7 @@ class InMemoryPassPhraseProviderMock: InMemoryPassPhraseProviderType {
         passPhrases.insert(passPhrase)
     }
 
-    func removePassPhrases(with objects: PassPhrase) {
-        if passPhrases.contains(objects) {
-            passPhrases.remove(objects)
-        }
+    func remove(passPhrases passPhrasesToDelete: Set<PassPhrase>) {
+        passPhrasesToDelete.forEach { passPhrases.remove($0) }
     }
 }

--- a/FlowCryptAppTests/LocalStorageTests.swift
+++ b/FlowCryptAppTests/LocalStorageTests.swift
@@ -14,6 +14,9 @@ class LocalStorageTests: XCTestCase {
 
     override func setUp() {
         sut = LocalStorage()
+
+        let passPhrase = PassPhrase(value: "123", fingerprints: ["123"], date: nil)
+        sut.passPhraseStorage.save(passPhrase: passPhrase)
     }
 
     var trashKey: String {
@@ -27,8 +30,12 @@ class LocalStorageTests: XCTestCase {
     }
 
     func testLogOutForUser() throws {
+        XCTAssertFalse(sut.passPhraseStorage.getPassPhrases().isEmpty)
+
         let user = "anton@gmail.com"
         try sut.logOutUser(email: user)
+        
         XCTAssertNil(UserDefaults.standard.string(forKey: trashKey))
+        XCTAssertTrue(sut.passPhraseStorage.getPassPhrases().isEmpty)
     }
 }


### PR DESCRIPTION
This PR implements deletion of in-memory passphrases on user logout.

close #587 

----------------------------------

**Tests**:
- Tests added or updated - updated `LocalStorageTests` to check passphrases deletion on logout

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
