### PR TITLE
Make UserObject required in ClientConfiguration

### DIFF
--- a/FlowCrypt/Controllers/Compose/ComposeViewController.swift
+++ b/FlowCrypt/Controllers/Compose/ComposeViewController.swift
@@ -685,19 +685,19 @@ extension ComposeViewController: UIImagePickerControllerDelegate, UINavigationCo
     ) {
         picker.dismiss(animated: true, completion: nil)
 
-        let attachment: ComposeMessageAttachment?
+        let composeMessageAttachment: ComposeMessageAttachment?
         switch picker.sourceType {
         case .camera:
-            attachment = ComposeMessageAttachment(cameraSourceMediaInfo: info)
+            composeMessageAttachment = ComposeMessageAttachment(cameraSourceMediaInfo: info)
         case .photoLibrary:
-            attachment = ComposeMessageAttachment(librarySourceMediaInfo: info)
+            composeMessageAttachment = ComposeMessageAttachment(librarySourceMediaInfo: info)
         default: fatalError("No other image picker's sources should be used")
         }
-        guard let att = attachment else {
+        guard let attachment = composeMessageAttachment else {
             showAlert(message: "files_picking_photos_error_message".localized)
             return
         }
-        appendAttachmentIfAllowed(att)
+        appendAttachmentIfAllowed(attachment)
         node.reloadSections(IndexSet(integer: 2), with: .automatic)
     }
 

--- a/FlowCrypt/Controllers/Settings/Contacts/Contacts List/ContactsListViewController.swift
+++ b/FlowCrypt/Controllers/Settings/Contacts/Contacts List/ContactsListViewController.swift
@@ -22,7 +22,7 @@ final class ContactsListViewController: TableNodeViewController {
 
     init(
         decorator: ContactsListDecoratorType = ContactsListDecorator(),
-        contactsProvider: LocalContactsProviderType = LocalContactsProvider(storage: DataService.shared.storage)
+        contactsProvider: LocalContactsProviderType = LocalContactsProvider()
     ) {
         self.decorator = decorator
         self.contactsProvider = contactsProvider

--- a/FlowCrypt/Functionality/Services/Contacts Services/ContactsService.swift
+++ b/FlowCrypt/Functionality/Services/Contacts Services/ContactsService.swift
@@ -32,7 +32,7 @@ struct ContactsService: ContactsServiceType {
     let pubLookup: PubLookupType
 
     init(
-        localContactsProvider: LocalContactsProviderType = LocalContactsProvider(storage: DataService.shared.storage),
+        localContactsProvider: LocalContactsProviderType = LocalContactsProvider(),
         pubLookup: PubLookupType = PubLookup()
     ) {
         self.localContactsProvider = localContactsProvider

--- a/FlowCrypt/Functionality/Services/Contacts Services/LocalContactsProvider.swift
+++ b/FlowCrypt/Functionality/Services/Contacts Services/LocalContactsProvider.swift
@@ -18,51 +18,50 @@ protocol LocalContactsProviderType: PublicKeyProvider {
     func getAllContacts() -> [Contact]
 }
 
-struct LocalContactsProvider: CacheServiceType {
-    let storage: CacheStorage
-    let localCache: CacheService<ContactObject>
+struct LocalContactsProvider {
+    private let localContactsCache: CacheService<ContactObject>
     let core: Core
 
-    init(storage: @escaping @autoclosure CacheStorage,
-         core: Core = .shared) {
-        self.storage = storage
-        self.localCache = CacheService(storage: storage())
+    init(
+        encryptedStorage: EncryptedStorageType = EncryptedStorage(),
+        core: Core = .shared
+    ) {
+        self.localContactsCache = CacheService<ContactObject>(encryptedStorage: encryptedStorage)
         self.core = core
     }
 }
 
 extension LocalContactsProvider: LocalContactsProviderType {
     func updateLastUsedDate(for email: String) {
-        let realm = storage()
-        let contact = realm
+        let contact = localContactsCache.realm
             .objects(ContactObject.self)
             .first(where: { $0.email == email })
 
-        try? realm.write {
+        try? localContactsCache.realm.write {
             contact?.lastUsed = Date()
         }
     }
 
     func retrievePubKey(for email: String) -> String? {
-        storage()
+        localContactsCache.encryptedStorage.storage
             .objects(ContactObject.self)
             .first(where: { $0.email == email })?
             .pubKey
     }
 
     func save(contact: Contact) {
-        localCache.save(ContactObject(contact))
+        localContactsCache.save(ContactObject(contact))
     }
 
     func remove(contact: Contact) {
-        localCache.remove(
+        localContactsCache.remove(
             object: ContactObject(contact),
             with: contact.email
         )
     }
 
     func searchContact(with email: String) -> Contact? {
-        storage()
+        localContactsCache.realm
             .objects(ContactObject.self)
             .first(where: { $0.email == email })
             .map { Contact($0) }
@@ -70,7 +69,7 @@ extension LocalContactsProvider: LocalContactsProviderType {
 
     func getAllContacts() -> [Contact] {
         Array(
-            storage()
+            localContactsCache.realm
                 .objects(ContactObject.self)
                 .map {
                     let keyDetail = try? core.parseKeys(armoredOrBinary: $0.pubKey.data()).keyDetails.first

--- a/FlowCrypt/Functionality/Services/Folders Services/LocalFoldersProvider.swift
+++ b/FlowCrypt/Functionality/Services/Folders Services/LocalFoldersProvider.swift
@@ -17,11 +17,9 @@ protocol LocalFoldersProviderType {
 
 struct LocalFoldersProvider: LocalFoldersProviderType {
     private let folderCache: CacheService<FolderObject>
-    private let encryptedStorage: EncryptedStorageType
 
     init(encryptedStorage: EncryptedStorageType = EncryptedStorage()) {
-        self.folderCache = CacheService(storage: encryptedStorage.storage)
-        self.encryptedStorage = encryptedStorage
+        self.folderCache = CacheService(encryptedStorage: encryptedStorage)
     }
 
     func fetchFolders() -> [FolderViewModel] {
@@ -31,7 +29,7 @@ struct LocalFoldersProvider: LocalFoldersProviderType {
     }
 
     func save(folders: [Folder]) {
-        guard let currentUser = encryptedStorage.activeUser else {
+        guard let currentUser = folderCache.encryptedStorage.activeUser else {
             return
         }
 

--- a/FlowCrypt/Functionality/Services/Organisational Rules Service/ClientConfigurationProvider.swift
+++ b/FlowCrypt/Functionality/Services/Organisational Rules Service/ClientConfigurationProvider.swift
@@ -16,13 +16,11 @@ protocol ClientConfigurationProviderType {
     func save(clientConfiguration: ClientConfiguration)
 }
 
-struct ClientConfigurationProvider: CacheServiceType {
-    let storage: CacheStorage
+struct ClientConfigurationProvider {
     let clientConfigurationCache: CacheService<ClientConfigurationObject>
 
-    init(storage: @escaping @autoclosure CacheStorage = DataService.shared.storage) {
-        self.storage = storage
-        self.clientConfigurationCache = CacheService(storage: storage())
+    init(encryptedStorage: EncryptedStorageType = EncryptedStorage()) {
+        self.clientConfigurationCache = CacheService(encryptedStorage: encryptedStorage)
     }
 }
 
@@ -36,6 +34,10 @@ extension ClientConfigurationProvider: ClientConfigurationProviderType {
     }
 
     func save(clientConfiguration: ClientConfiguration) {
-        clientConfigurationCache.save(ClientConfigurationObject(clientConfiguration, user: EncryptedStorage().activeUser))
+        guard let user = clientConfigurationCache.encryptedStorage.activeUser else {
+            assertionFailure("Internal inconsistency. Missed client configuration")
+            return
+        }
+        clientConfigurationCache.save(ClientConfigurationObject(clientConfiguration, user: user))
     }
 }

--- a/FlowCrypt/Models/Realm Models/ClientConfigurationObject.swift
+++ b/FlowCrypt/Models/Realm Models/ClientConfigurationObject.swift
@@ -17,8 +17,8 @@ final class ClientConfigurationObject: Object {
     @objc dynamic var disallowAttesterSearchForDomains: Data?
     @objc dynamic var enforceKeygenAlgo: String?
     @objc dynamic var enforceKeygenExpireMonths: Int = -1
-    @objc dynamic var user: UserObject?
-    @objc dynamic var userEmail: String?
+    @objc dynamic var user: UserObject!
+    @objc dynamic var userEmail: String!
 
     convenience init(
         flags: [String]?,
@@ -27,7 +27,7 @@ final class ClientConfigurationObject: Object {
         disallowAttesterSearchForDomains: [String]?,
         enforceKeygenAlgo: String?,
         enforceKeygenExpireMonths: Int?,
-        user: UserObject?
+        user: UserObject
     ) {
         self.init()
         if let flags = flags {
@@ -41,12 +41,12 @@ final class ClientConfigurationObject: Object {
         self.enforceKeygenAlgo = enforceKeygenAlgo
         self.enforceKeygenExpireMonths = enforceKeygenExpireMonths ?? -1
         self.user = user
-        self.userEmail = user?.email
+        self.userEmail = user.email
     }
 
     convenience init(
         _ clientConfiguration: ClientConfiguration,
-        user: UserObject?
+        user: UserObject
     ) {
         self.init(
             flags: clientConfiguration.flags?.map(\.rawValue),


### PR DESCRIPTION
This PR make `UserObject` required in `ClientConfiguration `
Refactored `CacheService`

close #600
----------------------------------

**Tests**:
- Does not need tests (refactor only)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
