### PR TITLE
Attachments names are not readable in dark mode

### DIFF
--- a/FlowCrypt/Controllers/Compose/ComposeViewDecorator.swift
+++ b/FlowCrypt/Controllers/Compose/ComposeViewDecorator.swift
@@ -64,7 +64,7 @@ struct ComposeViewDecorator {
             insets: UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
         )
     }
-    
+
     func styledMessage(with text: String) -> NSAttributedString {
         text.attributed(.regular(17))
     }
@@ -210,9 +210,9 @@ extension AttachmentNode.Input {
     init(composeAttachment: ComposeMessageAttachment) {
         self.init(
             name: composeAttachment.name
-                .attributed(.regular(18), color: .textColor, alignment: .left),
+                .attributed(.regular(18), color: .mainTextColor, alignment: .left),
             size: "\(composeAttachment.size)"
-                .attributed(.medium(12), color: .textColor, alignment: .left)
+                .attributed(.medium(12), color: .mainTextColor, alignment: .left)
         )
     }
 }

--- a/FlowCrypt/Controllers/Msg/MessageViewDecorator.swift
+++ b/FlowCrypt/Controllers/Msg/MessageViewDecorator.swift
@@ -49,9 +49,9 @@ extension AttachmentNode.Input {
     init(msgAttachment: MessageAttachment) {
         self.init(
             name: msgAttachment.name
-                .attributed(.regular(18), color: .textColor, alignment: .left),
+                .attributed(.regular(18), color: .mainTextColor, alignment: .left),
             size: "\(msgAttachment.size)"
-                .attributed(.medium(12), color: .textColor, alignment: .left)
+                .attributed(.medium(12), color: .mainTextColor, alignment: .left)
         )
     }
 }


### PR DESCRIPTION
This PR applies general text color that is used around the app

close #537

----------------------------------

**Tests**:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
