### PR TITLE
Don't add .pgp to file list when attaching files on compose screen

### DIFF
--- a/FlowCrypt/Functionality/Services/Compose Message Service/ComposeMessageAttachment.swift
+++ b/FlowCrypt/Functionality/Services/Compose Message Service/ComposeMessageAttachment.swift
@@ -35,7 +35,7 @@ extension ComposeMessageAttachment {
             guard let url = librarySourceMediaInfo[urlKey] as? URL else { return nil }
             let data = try Data(contentsOf: url)
 
-            self.name = "\(url.lastPathComponent).pgp"
+            self.name = url.lastPathComponent
             self.data = data
             self.size = data.count
             self.type = url.lastPathComponent.mimeType
@@ -50,7 +50,7 @@ extension ComposeMessageAttachment {
             return nil
         }
 
-        self.name = "\(UUID().uuidString).jpg.pgp"
+        self.name = "\(UUID().uuidString).jpg"
         self.data = data
         self.size = data.count
         self.type = "image/jpg"
@@ -61,7 +61,7 @@ extension ComposeMessageAttachment {
             return nil
         }
 
-        self.name = "\(fileURL.lastPathComponent).pgp"
+        self.name = fileURL.lastPathComponent
         self.data = data
         self.size = data.count
         self.type = fileURL.mimeType

--- a/FlowCrypt/Functionality/Services/Compose Message Service/ComposeMessageService.swift
+++ b/FlowCrypt/Functionality/Services/Compose Message Service/ComposeMessageService.swift
@@ -85,7 +85,7 @@ final class ComposeMessageService {
         let sendableAttachments: [SendableMsg.Attachment] = contextToSend.attachments
             .map { composeAttachment in
                 return SendableMsg.Attachment(
-                    name: composeAttachment.name,
+                    name: "\(composeAttachment.name).pgp",
                     type: composeAttachment.type,
                     base64: composeAttachment.data.base64EncodedString()
                 )


### PR DESCRIPTION
This PR adds .pgp extension to attachments right before sending them

close #538

----------------------------------

**Tests** :
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
