### PR TITLE
Bugfix/issue 603 attachments decrypt

### DIFF
--- a/FlowCrypt/Functionality/Mail Provider/Message Provider/MessageService.swift
+++ b/FlowCrypt/Functionality/Mail Provider/Message Provider/MessageService.swift
@@ -79,6 +79,9 @@ final class MessageService {
             }
 
             let keysWithFilledPassPhrase = keys.map { $0.copy(with: passPhrase) }
+            let keysToSave = keys.filter { $0.passphrase == passPhrase }
+
+            self.savePassPhrases(value: passPhrase, with: keysToSave)
 
             let decrypted = try self.core.parseDecryptMsg(
                 encrypted: rawMimeData,
@@ -91,7 +94,6 @@ final class MessageService {
                 return reject(MessageServiceError.wrongPassPhrase(rawMimeData, passPhrase))
             }
 
-            self.savePassPhrases(value: passPhrase, with: keys)
             let processedMessage = try self.processMessage(rawMimeData: rawMimeData, with: decrypted, keys: keys)
             resolve(processedMessage)
         }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -43,12 +43,12 @@ PODS:
   - PromisesObjC (2.0.0)
   - PromisesSwift (2.0.0):
     - PromisesObjC (= 2.0.0)
-  - Realm (10.16.0):
-    - Realm/Headers (= 10.16.0)
-  - Realm/Headers (10.16.0)
-  - RealmSwift (10.16.0):
-    - Realm (= 10.16.0)
-  - SwiftFormat/CLI (0.48.13)
+  - Realm (10.17.0):
+    - Realm/Headers (= 10.17.0)
+  - Realm/Headers (10.17.0)
+  - RealmSwift (10.17.0):
+    - Realm (= 10.17.0)
+  - SwiftFormat/CLI (0.48.14)
   - SwiftLint (0.44.0)
   - SwiftyRSA (1.7.0):
     - SwiftyRSA/ObjC (= 1.7.0)
@@ -130,9 +130,9 @@ SPEC CHECKSUMS:
   PINRemoteImage: f1295b29f8c5e640e25335a1b2bd9d805171bd01
   PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58
   PromisesSwift: e0b2a6433469efb0b83a2b84c62a2abab8e5e5d4
-  Realm: b6027801398f3743fc222f096faa85281b506e6c
-  RealmSwift: b02a3d0e4947955da960b642c98ad3a461fc4e70
-  SwiftFormat: 0c4b53c1acb503e2a743ecd9a18f51958d41d40a
+  Realm: 9533276bd76f66aa2fd0d3ffe700c1f6023dcab6
+  RealmSwift: 57f5d59aa29852587aad1e861989e7af139894b5
+  SwiftFormat: 45eb1675b89bee034a18693dfc550bd5c98d1b2d
   SwiftLint: e96c0a8c770c7ebbc4d36c55baf9096bb65c4584
   SwiftyRSA: 8c6dd1ea7db1b8dc4fb517a202f88bb1354bc2c6
   Texture: 2e8ab2519452515f7f5a520f5a8f7e0a413abfa3


### PR DESCRIPTION
This PR fixes attachments decryption when pass phrase is stored in memory.

close #603

----------------------------------

**Tests** _(delete all except exactly one)_:
- Difficult to test (explain why) - currently we don't have tests for `MessageService`, so test for this functionality probably will be added once we'll cover `MessageService` with tests.

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
