### PR TITLE
changed use another account button to back button

### DIFF
--- a/FlowCrypt/Controllers/Setup/SetupBackupsViewController.swift
+++ b/FlowCrypt/Controllers/Setup/SetupBackupsViewController.swift
@@ -18,7 +18,7 @@ import Promises
 
 final class SetupBackupsViewController: TableNodeViewController, PassPhraseSaveable, NavigationChildController {
     private enum Parts: Int, CaseIterable {
-        case title, description, passPhrase, divider, saveLocally, saveInMemory, action, optionalAction
+        case title, description, passPhrase, divider, saveLocally, saveInMemory, action
     }
 
     private lazy var logger = Logger.nested(in: Self.self, with: .setup)
@@ -30,7 +30,6 @@ final class SetupBackupsViewController: TableNodeViewController, PassPhraseSavea
     private let fetchedEncryptedKeys: [KeyDetails]
     private let keyStorage: KeyStorageType
     let passPhraseService: PassPhraseServiceType
-    var shouldShowBackButton: Bool { false }
 
     private var passPhrase: String?
 
@@ -183,7 +182,7 @@ extension SetupBackupsViewController {
         }
     }
 
-    private func handleOtherAccount() {
+    func handleBackButtonTap() {
         router.signOut()
     }
 
@@ -241,10 +240,6 @@ extension SetupBackupsViewController: ASTableDelegate, ASTableDataSource {
                 }
                 .then {
                     $0.button.accessibilityIdentifier = "load_account"
-                }
-            case .optionalAction:
-                return ButtonCellNode(input: .chooseAnotherAccount) { [weak self] in
-                    self?.handleOtherAccount()
                 }
             case .divider:
                 return DividerCellNode(inset: self.decorator.insets.dividerInsets)

--- a/FlowCrypt/Controllers/Setup/SetupCreatePassphraseAbstractViewController.swift
+++ b/FlowCrypt/Controllers/Setup/SetupCreatePassphraseAbstractViewController.swift
@@ -18,7 +18,7 @@ import Promises
 
 class SetupCreatePassphraseAbstractViewController: TableNodeViewController, PassPhraseSaveable, NavigationChildController {
     enum Parts: Int, CaseIterable {
-        case title, description, passPhrase, divider, saveLocally, saveInMemory, action, optionalAction, subtitle, fetchedKeys
+        case title, description, passPhrase, divider, saveLocally, saveInMemory, action, subtitle, fetchedKeys
     }
 
     var parts: [Parts] {
@@ -33,7 +33,6 @@ class SetupCreatePassphraseAbstractViewController: TableNodeViewController, Pass
     let storage: DataServiceType
     let keyStorage: KeyStorageType
     let passPhraseService: PassPhraseServiceType
-    var shouldShowBackButton: Bool { false }
 
     var storageMethod: StorageMethod = .persistent {
         didSet {
@@ -96,6 +95,10 @@ class SetupCreatePassphraseAbstractViewController: TableNodeViewController, Pass
 
         title = decorator.sceneTitle(for: .createKey)
         observeKeyboardNotifications()
+    }
+
+    func handleBackButtonTap() {
+        router.signOut()
     }
 }
 
@@ -201,10 +204,6 @@ extension SetupCreatePassphraseAbstractViewController {
         logger.logInfo("Setup account with passphrase")
         setupAccount(with: passPhrase)
     }
-
-    private func handleOtherAccount() {
-        router.signOut()
-    }
 }
 
 // MARK: - ASTableDelegate, ASTableDataSource
@@ -264,10 +263,6 @@ extension SetupCreatePassphraseAbstractViewController: ASTableDelegate, ASTableD
                         backgroundColor: .backgroundColor
                     )
                 )
-            case .optionalAction:
-                return ButtonCellNode(input: .chooseAnotherAccount) { [weak self] in
-                    self?.handleOtherAccount()
-                }
             case .divider:
                 return DividerCellNode(inset: self.decorator.insets.dividerInsets)
             case .saveLocally:

--- a/FlowCrypt/Controllers/Setup/SetupEKMKeyViewController.swift
+++ b/FlowCrypt/Controllers/Setup/SetupEKMKeyViewController.swift
@@ -125,6 +125,6 @@ extension SetupEKMKeyViewController {
 
 extension SetupCreatePassphraseAbstractViewController.Parts {
     static var ekmKeysSetup: [SetupCreatePassphraseAbstractViewController.Parts] {
-        return [.title, .description, .passPhrase, .divider, .action, .optionalAction, .fetchedKeys]
+        return [.title, .description, .passPhrase, .divider, .action, .fetchedKeys]
     }
 }


### PR DESCRIPTION
This PR changes use another account button to back button, except in `SetupManuallyEnterPassPhraseViewController` because it is root viewController of navigation stack

close #596

----------------------------------

**Tests**:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
