### PR TITLE
issue #712 move colors to global constants

### DIFF
--- a/FlowCrypt/Controllers/Compose/ComposeViewDecorator.swift
+++ b/FlowCrypt/Controllers/Compose/ComposeViewDecorator.swift
@@ -135,14 +135,6 @@ extension UIColor {
             lightStyle: UIColor.black.withAlphaComponent(0.3)
         )
     }
-
-    static var expiredKeyColor: UIColor {
-        UIColor(r: 194, g: 126, b: 35)
-    }
-
-    static var revokedKeyColor: UIColor {
-        UIColor(r: 209, g: 72, b: 54)
-    }
 }
 
 // MARK: - RecipientState
@@ -176,7 +168,7 @@ extension ComposeViewDecorator {
 
     private static var keyExpiredStateContext: RecipientStateContext {
         RecipientStateContext(
-            backgroundColor: .expiredKeyColor,
+            backgroundColor: .warningColor,
             borderColor: .borderColor,
             textColor: .white,
             image: nil
@@ -185,7 +177,7 @@ extension ComposeViewDecorator {
 
     private static var keyRevokedStateContext: RecipientStateContext {
         RecipientStateContext(
-            backgroundColor: .revokedKeyColor,
+            backgroundColor: .errorColor,
             borderColor: .borderColor,
             textColor: .white,
             image: nil

--- a/FlowCrypt/Extensions/UIColorExtension.swift
+++ b/FlowCrypt/Extensions/UIColorExtension.swift
@@ -18,6 +18,14 @@ extension UIColor {
         UIColor(r: 57, g: 57, b: 57, alpha: 1)
     }
 
+    static var warningColor: UIColor {
+        UIColor(r: 194, g: 126, b: 35)
+    }
+
+    static var errorColor: UIColor {
+        UIColor(r: 209, g: 72, b: 54)
+    }
+
     static var mainTextColor: UIColor {
         UIColor.colorFor(
             darkStyle: .white,


### PR DESCRIPTION
This PR moves color constants from `ComposeViewDecorator` to `UIColor` extension

issue #712

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
