### PR TITLE
Message sender text and message subject text is selectable now

### DIFF
--- a/FlowCryptUI/Cell Nodes/MessageSenderNode.swift
+++ b/FlowCryptUI/Cell Nodes/MessageSenderNode.swift
@@ -12,7 +12,7 @@ import FlowCryptCommon
 public final class MessageSenderNode: CellNode {
     public typealias ButtonAction = () -> Void
 
-    private let textNode = ASTextNode2()
+    private let textNode = ASEditableTextNode()
     private let buttonNode = ASButtonNode()
     private let onTap: ButtonAction?
 
@@ -20,6 +20,10 @@ public final class MessageSenderNode: CellNode {
         onTap = action
         super.init()
         textNode.attributedText = text
+        DispatchQueue.main.async { [weak self] in
+            self?.textNode.textView.isSelectable = true
+            self?.textNode.textView.isEditable = false
+        }
         buttonNode.accessibilityLabel = "reply-all"
         buttonNode.setImage(UIImage(named: "reply-all")?.tinted(.main), for: .normal)
         buttonNode.addTarget(self, action: #selector(tapHandler), forControlEvents: .touchUpInside)

--- a/FlowCryptUI/Cell Nodes/MessageSubjectNode.swift
+++ b/FlowCryptUI/Cell Nodes/MessageSubjectNode.swift
@@ -9,12 +9,16 @@
 import AsyncDisplayKit
 
 public final class MessageSubjectNode: CellNode {
-    private let textNode = ASTextNode2()
+    private let textNode = ASEditableTextNode()
     private let timeNode = ASTextNode2()
 
     public init(_ text: NSAttributedString?, time: NSAttributedString?) {
         super.init()
         textNode.attributedText = text
+        DispatchQueue.main.async {
+            self.textNode.textView.isSelectable = true
+            self.textNode.textView.isEditable = false
+        }
         timeNode.attributedText = time
     }
 


### PR DESCRIPTION
This PR makes the subject text and sender email text selectable for the sake of copying. 

close #662  // if this PR closes an issue

issue #662  // if it doesn't close the issue yet

----------------------------------

**Tests** _(delete all except exactly one)_:
- Not worth testing

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
