### PR TITLE
delete .app after build before moving new one

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,6 +21,7 @@ platform :ios do
        configuration: "Debug",
        xcargs: "-sdk iphonesimulator SYMROOT='/var/tmp/'"
     )
+    sh("rm -rf ~/git/flowcrypt-ios/appium/FlowCrypt.app")
     sh("mv /var/tmp/Debug-iphonesimulator/FlowCrypt.app ~/git/flowcrypt-ios/appium/")
   end
 


### PR DESCRIPTION
This PR removes previous `FlowCrypt.app` on fastlane build, so that new one can be moved over.

no issue
