### PR TITLE
issue 743 contacts.other search

### DIFF
--- a/FlowCrypt/Controllers/CheckAuthScopes/CheckAuthScopesViewController.swift
+++ b/FlowCrypt/Controllers/CheckAuthScopes/CheckAuthScopesViewController.swift
@@ -16,6 +16,7 @@ private extension GoogleScope {
         case .userInfo: return "User Info"
         case .mail: return "Gmail"
         case .contacts: return "Contacts"
+        case .otherContacts: return "Other Contacts"
         }
     }
 }

--- a/FlowCrypt/Functionality/Services/GeneralConstants.swift
+++ b/FlowCrypt/Functionality/Services/GeneralConstants.swift
@@ -29,13 +29,14 @@ enum GeneralConstants {
 }
 
 enum GoogleScope: CaseIterable {
-    case userInfo, mail, contacts
+    case userInfo, mail, contacts, otherContacts
 
     var value: String {
         switch self {
         case .userInfo: return "https://www.googleapis.com/auth/userinfo.profile"
         case .mail: return "https://mail.google.com/"
         case .contacts: return "https://www.googleapis.com/auth/contacts"
+        case .otherContacts: return "https://www.googleapis.com/auth/contacts.other.readonly"
         }
     }
 }

--- a/FlowCryptAppTests/GeneralConstantsTest.swift
+++ b/FlowCryptAppTests/GeneralConstantsTest.swift
@@ -29,7 +29,8 @@ class GeneralConstantsTest: XCTestCase {
         let expectedScope = Set([
             "https://www.googleapis.com/auth/userinfo.profile",
             "https://mail.google.com/",
-            "https://www.googleapis.com/auth/contacts"
+            "https://www.googleapis.com/auth/contacts",
+            "https://www.googleapis.com/auth/contacts.other.readonly"
         ])
         XCTAssert(currentScope == expectedScope)
 


### PR DESCRIPTION
This PR adds search through email addresses which are not stored in user's Gmail contacts. It also needs additional auth scope `https://www.googleapis.com/auth/contacts.other.readonly` (currently it shows warning screen when user authenticates for the first time)

close #743

----------------------------------

**Tests** _(delete all except exactly one)_:
- Difficult to test (explain why) - it needs Google auth for testing search results.

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
