### PR TITLE
issue 803 quit appium on unhandled promise

### DIFF
--- a/appium/config/wdio.ios.app.conf.js
+++ b/appium/config/wdio.ios.app.conf.js
@@ -3,6 +3,12 @@ const { config } = require('./wdio.shared.conf');
 const pathWdioConfig = require('path');
 require('dotenv').config({ path: pathWdioConfig.resolve(__dirname, '../.env') });
 
+process.on('unhandledRejection', (reason, promise) => {
+    // without this, after lib update to v7, whole test suite may pass even if no tests ran successfully
+    console.error('Force-quitting node process because unhandled rejection at:', promise, 'reason:', reason);
+    process.exit(1);
+});
+
 config.suites = {
     all: [
         './tests/specs/**/*.spec.ts'


### PR DESCRIPTION
This PR quits appium when there is an unhandled promise so that tests don't pass blindly.

close #803

----------------------------------

**Tests**
- Tests runner updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
