### PR TITLE
Sending messages with larger attachments, disabled phone sleep while …

### DIFF
--- a/FlowCrypt/Controllers/Compose/ComposeViewController.swift
+++ b/FlowCrypt/Controllers/Compose/ComposeViewController.swift
@@ -7,6 +7,7 @@ import Combine
 import FlowCryptCommon
 import FlowCryptUI
 import Foundation
+import UIKit
 
 /**
  * View controller to compose the message and send it
@@ -393,6 +394,7 @@ extension ComposeViewController {
             )
             switch result {
             case .success(let message):
+                UIApplication.shared.isIdleTimerDisabled = true
                 self.encryptAndSend(message)
             case .failure(let error):
                 self.handle(error: error)
@@ -418,6 +420,7 @@ extension ComposeViewController {
     }
 
     private func handle(error: ComposeMessageError) {
+        UIApplication.shared.isIdleTimerDisabled = false
         hideSpinner()
         navigationItem.rightBarButtonItem?.isEnabled = true
 
@@ -429,6 +432,7 @@ extension ComposeViewController {
     }
 
     private func handleSuccessfullySentMessage() {
+        UIApplication.shared.isIdleTimerDisabled = false
         hideSpinner()
         navigationItem.rightBarButtonItem?.isEnabled = true
         showToast(input.successfullySentToast)


### PR DESCRIPTION
…uploading

This PR adds the code which doesn't allow iPhone app to go to sleep mode until the attachment is uploaded while sending message. No matter how slow the internet may be.

close #605  // if this PR closes an issue

issue #605  // if it doesn't close the issue yet

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests will be added later (issue #...)
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
