### PR TITLE
issue #812 add user emails to PubKey

### DIFF
--- a/FlowCrypt/Functionality/Services/Local Pub Key Services/Models/PubKey.swift
+++ b/FlowCrypt/Functionality/Services/Local Pub Key Services/Models/PubKey.swift
@@ -26,6 +26,8 @@ struct PubKey {
     let algo: KeyAlgo?
     /// is key revoked
     let isRevoked: Bool
+    /// user emails
+    let emails: [String]
 }
 
 extension PubKey {
@@ -59,7 +61,8 @@ extension PubKey {
                   fingerprints: fingerprints,
                   created: Date(timeIntervalSince1970: Double(keyDetails.created)),
                   algo: keyDetails.algo,
-                  isRevoked: keyDetails.revoked)
+                  isRevoked: keyDetails.revoked,
+                  emails: keyDetails.pgpUserEmails)
     }
 }
 

--- a/FlowCryptAppTests/Functionality/Services/Key Services/Models/RecipientTests.swift
+++ b/FlowCryptAppTests/Functionality/Services/Key Services/Models/RecipientTests.swift
@@ -14,7 +14,7 @@ class RecipientTests: XCTestCase {
 
     func testRecipientWithRevokedKey() {
         let keyDetails = KeyStorageMock.createFakeKeyDetails(expiration: nil, revoked: true)
-        let recipient = RecipientWithSortedPubKeys(email: "test@test.com", keyDetails: [keyDetails])
+        let recipient = RecipientWithSortedPubKeys(email: "test@flowcrypt.com", keyDetails: [keyDetails])
 
         XCTAssertEqual(recipient.keyState, .revoked)
     }
@@ -23,23 +23,24 @@ class RecipientTests: XCTestCase {
         let expiration = Date().timeIntervalSince1970 - 60 * 60
         let keyDetails = KeyStorageMock.createFakeKeyDetails(expiration: Int(expiration))
 
-        let recipient = RecipientWithSortedPubKeys(email: "test@test.com", keyDetails: [keyDetails])
+        let recipient = RecipientWithSortedPubKeys(email: "test@flowcrypt.com", keyDetails: [keyDetails])
         XCTAssertEqual(recipient.keyState, .expired)
     }
 
     func testRecipientWithValidKey() {
         let expiration = Date().timeIntervalSince1970 + 60 * 60
         let keyDetails = KeyStorageMock.createFakeKeyDetails(expiration: Int(expiration))
-        let recipient = RecipientWithSortedPubKeys(email: "test@test.com", keyDetails: [keyDetails])
+        let recipient = RecipientWithSortedPubKeys(email: "test@flowcrypt.com", keyDetails: [keyDetails])
         XCTAssertEqual(recipient.keyState, .active)
+        XCTAssertEqual(recipient.pubKeys.first?.emails, ["test@flowcrypt.com"])
 
         let keyDetails2 = KeyStorageMock.createFakeKeyDetails(expiration: nil)
-        let recipient2 = RecipientWithSortedPubKeys(email: "test@test.com", keyDetails: [keyDetails2])
+        let recipient2 = RecipientWithSortedPubKeys(email: "test@flowcrypt.com", keyDetails: [keyDetails2])
         XCTAssertEqual(recipient2.keyState, .active)
     }
 
     func testRecipientWithoutPubKey() {
-        let recipient = RecipientWithSortedPubKeys(email: "test@test.com", keyDetails: [])
+        let recipient = RecipientWithSortedPubKeys(email: "test@flowcrypt.com", keyDetails: [])
         XCTAssertEqual(recipient.keyState, .empty)
     }
 
@@ -56,7 +57,7 @@ class RecipientTests: XCTestCase {
         let oldExpiredKey = KeyStorageMock.createFakeKeyDetails(expiration: now - 2 * 3600)
 
         let keyDetails = [revokedKey, oldExpiredKey, activeKey1, expiredKey, activeKey2, nonExpiringKey, activeKey3]
-        let recipient = RecipientWithSortedPubKeys(email: "test@test.com",
+        let recipient = RecipientWithSortedPubKeys(email: "test@flowcrypt.com",
                                                    keyDetails: keyDetails)
 
         XCTAssertEqual(recipient.pubKeys[0].fingerprint, nonExpiringKey.primaryFingerprint)

--- a/FlowCryptAppTests/Mocks/KeyStorageMock.swift
+++ b/FlowCryptAppTests/Mocks/KeyStorageMock.swift
@@ -39,7 +39,7 @@ extension KeyStorageMock {
             created: 1,
             lastModified: nil,
             expiration: expiration,
-            users: [],
+            users: ["Test User <test@flowcrypt.com>"],
             algo: nil,
             revoked: revoked
         )


### PR DESCRIPTION
This PR adds user emails to PubKey

close #812

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated - updated `testRecipientWithValidKey` test to check parsed `PubKey` emails.

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
