### PR TITLE
issues 948 950 960 fix inbox conversations data

### DIFF
--- a/FlowCrypt/Controllers/Inbox/InboxProviders.swift
+++ b/FlowCrypt/Controllers/Inbox/InboxProviders.swift
@@ -14,11 +14,12 @@ struct InboxContext {
 }
 
 class InboxDataProvider {
-    func fetchMessages(using context: FetchMessageContext) async throws -> InboxContext {
+    func fetchInboxItems(using context: FetchMessageContext) async throws -> InboxContext {
         fatalError("Should be implemented")
     }
 }
 
+// used when displaying conversations (threads) in inbox (Gmail API default)
 class InboxMessageThreadsProvider: InboxDataProvider {
     let provider: MessagesThreadProvider
 
@@ -26,7 +27,7 @@ class InboxMessageThreadsProvider: InboxDataProvider {
         self.provider = provider
     }
 
-    override func fetchMessages(using context: FetchMessageContext) async throws -> InboxContext {
+    override func fetchInboxItems(using context: FetchMessageContext) async throws -> InboxContext {
         let result = try await provider.fetchThreads(using: context)
         let inboxData = result.threads.map(InboxRenderable.init)
         let inboxContext = InboxContext(
@@ -37,6 +38,7 @@ class InboxMessageThreadsProvider: InboxDataProvider {
     }
 }
 
+// used when displaying individual messages in inbox (IMAP)
 class InboxMessageListProvider: InboxDataProvider {
     let provider: MessagesListProvider
 
@@ -44,7 +46,7 @@ class InboxMessageListProvider: InboxDataProvider {
         self.provider = provider
     }
 
-    override func fetchMessages(using context: FetchMessageContext) async throws -> InboxContext {
+    override func fetchInboxItems(using context: FetchMessageContext) async throws -> InboxContext {
         let result = try await provider.fetchMessages(using: context)
         let inboxData = result.messages.map(InboxRenderable.init)
         let inboxContext = InboxContext(

--- a/FlowCrypt/Controllers/Inbox/InboxRenderable.swift
+++ b/FlowCrypt/Controllers/Inbox/InboxRenderable.swift
@@ -25,12 +25,6 @@ struct InboxRenderable {
     let wrappedType: WrappedType
 }
 
-extension InboxRenderable: Comparable {
-    static func < (lhs: InboxRenderable, rhs: InboxRenderable) -> Bool {
-        lhs.date > rhs.date
-    }
-}
-
 extension InboxRenderable {
     var wrappedMessage: Message? {
         guard case .message(let message) = wrappedType else {
@@ -56,23 +50,19 @@ extension InboxRenderable {
             .compactMap { $0.components(separatedBy: "@").first ?? "" }
             .unique()
             .joined(separator: ",")
-
         self.title = sender
         self.messageCount = thread.messages.count
         self.subtitle = thread.subject ?? "message_missed_subject".localized
-
-        if let date = thread.messages.first?.date {
+        self.isRead = !thread.messages
+            .map(\.isMessageRead)
+            .contains(false)
+        let date = thread.messages.last?.date
+        if let date = date {
             self.dateString = DateFormatter().formatDate(date)
         } else {
             self.dateString = ""
         }
-
-        self.isRead = !thread.messages
-            .map(\.isMessageRead)
-            .contains(false)
-
-        self.date = thread.messages.first?.date ?? Date()
-
+        self.date = date ?? Date()
         self.wrappedType = .thread(thread)
     }
 }

--- a/FlowCrypt/Controllers/Inbox/InboxViewController+Factory.swift
+++ b/FlowCrypt/Controllers/Inbox/InboxViewController+Factory.swift
@@ -17,21 +17,23 @@ class InboxViewControllerFactory {
 
         switch currentAuthType {
         case .oAuthGmail:
-            // Inject threads provide
+            // Inject threads provider - Gmail API
             guard let threadsProvider = MailProvider.shared.messagesThreadProvider else {
                 fatalError("Internal inconsistency")
             }
 
             return InboxViewController(
                 viewModel,
+                numberOfInboxRenderablesToLoad: 20, // else timeouts happen
                 provider: InboxMessageThreadsProvider(provider: threadsProvider)
             )
         case .password:
-            // Inject message list provider
+            // Inject message list provider - IMAP
             let provider = InboxMessageListProvider()
 
             return InboxViewController(
                 viewModel,
+                numberOfInboxRenderablesToLoad: 50, // safe to load 50, single call on IMAP
                 provider: provider
             )
         }

--- a/FlowCrypt/Controllers/Inbox/InboxViewController+Factory.swift
+++ b/FlowCrypt/Controllers/Inbox/InboxViewController+Factory.swift
@@ -24,7 +24,7 @@ class InboxViewControllerFactory {
 
             return InboxViewController(
                 viewModel,
-                numberOfInboxRenderablesToLoad: 20, // else timeouts happen
+                numberOfInboxItemsToLoad: 20, // else timeouts happen
                 provider: InboxMessageThreadsProvider(provider: threadsProvider)
             )
         case .password:
@@ -33,7 +33,7 @@ class InboxViewControllerFactory {
 
             return InboxViewController(
                 viewModel,
-                numberOfInboxRenderablesToLoad: 50, // safe to load 50, single call on IMAP
+                numberOfInboxItemsToLoad: 50, // safe to load 50, single call on IMAP
                 provider: provider
             )
         }

--- a/FlowCrypt/Controllers/Inbox/InboxViewController.swift
+++ b/FlowCrypt/Controllers/Inbox/InboxViewController.swift
@@ -10,7 +10,7 @@ import Foundation
 final class InboxViewController: ASDKViewController<ASDisplayNode> {
     private lazy var logger = Logger.nested(Self.self)
 
-    private let numberOfInboxRenderablesToLoad: Int
+    private let numberOfInboxItemsToLoad: Int
 
     private let service: ServiceActor
     private let decorator: InboxViewDecorator
@@ -32,13 +32,13 @@ final class InboxViewController: ASDKViewController<ASDisplayNode> {
 
     init(
         _ viewModel: InboxViewModel,
-        numberOfInboxRenderablesToLoad: Int = 50,
+        numberOfInboxItemsToLoad: Int = 50,
         provider: InboxDataProvider,
         draftsListProvider: DraftsListProvider? = MailProvider.shared.draftsProvider,
         decorator: InboxViewDecorator = InboxViewDecorator()
     ) {
         self.viewModel = viewModel
-        self.numberOfInboxRenderablesToLoad = numberOfInboxRenderablesToLoad
+        self.numberOfInboxItemsToLoad = numberOfInboxItemsToLoad
 
         self.service = ServiceActor(inboxDataProvider: provider)
         self.draftsListProvider = draftsListProvider
@@ -123,15 +123,15 @@ extension InboxViewController {
     private func messagesToLoad() -> Int {
         switch state {
         case .fetched(.byNextPage):
-            return numberOfInboxRenderablesToLoad
+            return numberOfInboxItemsToLoad
         case .fetched(.byNumber(let totalNumberOfMessages)):
             guard let total = totalNumberOfMessages else {
-                return numberOfInboxRenderablesToLoad
+                return numberOfInboxItemsToLoad
             }
             let from = inboxInput.count
-            return min(numberOfInboxRenderablesToLoad, total - from)
+            return min(numberOfInboxItemsToLoad, total - from)
         default:
-            return numberOfInboxRenderablesToLoad
+            return numberOfInboxItemsToLoad
         }
     }
 }
@@ -152,7 +152,7 @@ extension InboxViewController {
                 let context = try await draftsProvider.fetchDrafts(
                     using: FetchMessageContext(
                         folderPath: viewModel.path,
-                        count: numberOfInboxRenderablesToLoad,
+                        count: numberOfInboxItemsToLoad,
                         pagination: currentMessagesListPagination()
                     )
                 )
@@ -173,7 +173,7 @@ extension InboxViewController {
                 let context = try await service.fetchInboxItems(
                     using: FetchMessageContext(
                         folderPath: viewModel.path,
-                        count: numberOfInboxRenderablesToLoad,
+                        count: numberOfInboxItemsToLoad,
                         pagination: currentMessagesListPagination()
                     )
                 )

--- a/FlowCrypt/Functionality/Mail Provider/Threads/MessagesThreadProvider.swift
+++ b/FlowCrypt/Functionality/Mail Provider/Threads/MessagesThreadProvider.swift
@@ -15,8 +15,7 @@ protocol MessagesThreadProvider {
 
 extension GmailService: MessagesThreadProvider {
     func fetchThreads(using context: FetchMessageContext) async throws -> MessageThreadContext {
-        let threadsList = try await getThreadsList(using: context)
-
+        let threadsList = (try await getThreadsList(using: context))
         let requests = threadsList.threads?
             .compactMap { (thread) -> (String, String?)? in
                 guard let id = thread.identifier else {
@@ -25,20 +24,21 @@ extension GmailService: MessagesThreadProvider {
                 return (id, thread.snippet)
             }
         ?? []
-
         return try await withThrowingTaskGroup(of: MessageThread.self) { (taskGroup) in
-            var messages: [MessageThread] = []
+            var messageThreadsById: [String: MessageThread] = [:]
             for request in requests {
                 taskGroup.addTask {
                     try await self.getThread(with: request.0, snippet: request.1, path: context.folderPath ?? "")
                 }
             }
             for try await result in taskGroup {
-                messages.append(result)
+                if let id = result.identifier {
+                    messageThreadsById[id] = result
+                }
             }
-
+            let messageThreads = requests.compactMap { messageThreadsById[$0.0] }
             return MessageThreadContext(
-                threads: messages,
+                threads: messageThreads,
                 pagination: .byNextPage(token: threadsList.nextPageToken)
             )
         }


### PR DESCRIPTION
This PR:
 - close #960 - was date of first msg instead of last
 - close #948 - reduced concurrency
 - close #950 - just wrong ordering
 - renames various vars and methods for clarity

`for try await result in taskGroup` seems to execute in order that the tasks finish, not necessarily in the order in which the `taskGroup` array was defined. Instead of using an array to collect results, using a dict by id now, which is then converted to array in expected order.

When the order is kept correct that way, `.sort()` is no longer needed on the result. The sort was broken anyway, sorting by first message in thread. 

----------------------------------

**Tests**:
 - tests will be added in https://github.com/FlowCrypt/flowcrypt-ios/issues/959

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
