### PR TITLE
issue 966 always return on continuation.resume

### DIFF
--- a/FlowCrypt/Controllers/Compose/ComposeViewController.swift
+++ b/FlowCrypt/Controllers/Compose/ComposeViewController.swift
@@ -357,23 +357,22 @@ extension ComposeViewController {
         return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<String, Error>) in
             let alert = AlertsFactory.makePassPhraseAlert(
                 onCancel: {
-                    continuation.resume(throwing: AppErr.user("Passphrase is required for message signing"))
+                    return continuation.resume(throwing: AppErr.user("Passphrase is required for message signing"))
                 },
                 onCompletion: { [weak self] passPhrase in
                     guard let self = self else {
-                        continuation.resume(throwing: AppErr.nilSelf)
-                        return
+                        return continuation.resume(throwing: AppErr.nilSelf)
                     }
                     Task {
                         do {
                             let matched = try await self.handlePassPhraseEntry(passPhrase, for: signingKey)
                             if matched {
-                                continuation.resume(returning: passPhrase)
+                                return continuation.resume(returning: passPhrase)
                             } else {
                                 throw AppErr.user("This pass phrase did not match your signing private key")
                             }
                         } catch {
-                            continuation.resume(throwing: error)
+                            return continuation.resume(throwing: error)
                         }
                     }
                 }

--- a/FlowCrypt/Controllers/Compose/ComposeViewController.swift
+++ b/FlowCrypt/Controllers/Compose/ComposeViewController.swift
@@ -363,7 +363,7 @@ extension ComposeViewController {
                     guard let self = self else {
                         return continuation.resume(throwing: AppErr.nilSelf)
                     }
-                    Task {
+                    Task<Void, Never> {
                         do {
                             let matched = try await self.handlePassPhraseEntry(passPhrase, for: signingKey)
                             if matched {

--- a/FlowCrypt/Controllers/MessageList Extension/MsgListViewController.swift
+++ b/FlowCrypt/Controllers/MessageList Extension/MsgListViewController.swift
@@ -50,7 +50,6 @@ extension MsgListViewController where Self: UIViewController {
     }
 
     private func openThread(with thread: MessageThread) {
-        // TODO https://github.com/FlowCrypt/flowcrypt-ios/issues/908
         guard let threadOperationsProvider = MailProvider.shared.threadOperationsProvider else {
             assertionFailure("Internal error. Provider should conform to MessagesThreadOperationsProvider")
             return

--- a/FlowCrypt/Controllers/Setup/SetupCreatePassphraseAbstractViewController.swift
+++ b/FlowCrypt/Controllers/Setup/SetupCreatePassphraseAbstractViewController.swift
@@ -165,10 +165,10 @@ extension SetupCreatePassphraseAbstractViewController {
                 }
 
                 alert.addAction(UIAlertAction(title: "cancel".localized, style: .default) { _ in
-                    continuation.resume(returning: nil)
+                    return continuation.resume(returning: nil)
                 })
                 alert.addAction(UIAlertAction(title: "ok".localized, style: .default) { [weak alert] _ in
-                    continuation.resume(returning: alert?.textFields?[0].text)
+                    return continuation.resume(returning: alert?.textFields?[0].text)
                 })
 
                 self.present(alert, animated: true, completion: nil)

--- a/FlowCrypt/Controllers/Threads/ThreadDetailsViewController.swift
+++ b/FlowCrypt/Controllers/Threads/ThreadDetailsViewController.swift
@@ -62,6 +62,7 @@ final class ThreadDetailsViewController: TableNodeViewController {
         self.messageOperationsProvider = messageOperationsProvider
         self.trashFolderProvider = trashFolderProvider
         self.thread = thread
+        print("thread.messages: \(thread.messages)")
         self.filesManager = filesManager
         self.onComplete = completion
         self.input = thread.messages

--- a/FlowCrypt/Functionality/Mail Provider/Contacts Provider/CloudContactsProvider.swift
+++ b/FlowCrypt/Functionality/Mail Provider/Contacts Provider/CloudContactsProvider.swift
@@ -94,18 +94,15 @@ extension UserContactsProvider {
         try await withCheckedThrowingContinuation { continuation in
             self.peopleService.executeQuery(query) { _, data, error in
                 if let error = error {
-                    continuation.resume(throwing: CloudContactsProviderError.providerError(error))
-                    return
+                    return continuation.resume(throwing: CloudContactsProviderError.providerError(error))
                 }
 
                 guard let response = data as? GTLRPeopleService_SearchResponse else {
-                    continuation.resume(throwing: AppErr.cast("GTLRPeopleService_SearchResponse"))
-                    return
+                    return continuation.resume(throwing: AppErr.cast("GTLRPeopleService_SearchResponse"))
                 }
 
                 guard let contacts = response.results else {
-                    continuation.resume(throwing: CloudContactsProviderError.failedToParseData(data))
-                    return
+                    return continuation.resume(throwing: CloudContactsProviderError.failedToParseData(data))
                 }
 
                 let emails = contacts
@@ -113,7 +110,7 @@ extension UserContactsProvider {
                     .flatMap { $0 }
                     .compactMap { $0.value }
 
-                continuation.resume(returning: emails)
+                return continuation.resume(returning: emails)
             }
         }
     }

--- a/FlowCrypt/Functionality/Mail Provider/Message Gateway/GmailService+draft.swift
+++ b/FlowCrypt/Functionality/Mail Provider/Message Gateway/GmailService+draft.swift
@@ -13,8 +13,7 @@ extension GmailService: DraftGateway {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<GTLRGmail_Draft, Error>) in
 
             guard let raw = GTLREncodeBase64(input.mime) else {
-                continuation.resume(throwing: GmailServiceError.messageEncode)
-                return
+                return continuation.resume(throwing: GmailServiceError.messageEncode)
             }
             let draftQuery = createQueryForDraftAction(
                 raw: raw,
@@ -23,11 +22,11 @@ extension GmailService: DraftGateway {
 
             gmailService.executeQuery(draftQuery) { _, object, error in
                 if let error = error {
-                    continuation.resume(throwing: GmailServiceError.providerError(error))
+                    return continuation.resume(throwing: GmailServiceError.providerError(error))
                 } else if let draft = object as? GTLRGmail_Draft {
-                    continuation.resume(returning: (draft))
+                    return continuation.resume(returning: (draft))
                 } else {
-                    continuation.resume(throwing: GmailServiceError.failedToParseData(nil))
+                    return continuation.resume(throwing: GmailServiceError.failedToParseData(nil))
                 }
             }
         }
@@ -37,7 +36,7 @@ extension GmailService: DraftGateway {
         await withCheckedContinuation{ (continuation: CheckedContinuation<Void, Never>) in
             let query = GTLRGmailQuery_UsersDraftsDelete.query(withUserId: .me, identifier: identifier)
             gmailService.executeQuery(query) { _, _, _ in
-                continuation.resume()
+                return continuation.resume()
             }
         }
     }

--- a/FlowCrypt/Functionality/Mail Provider/Message Gateway/GmailService+send.swift
+++ b/FlowCrypt/Functionality/Mail Provider/Message Gateway/GmailService+send.swift
@@ -13,8 +13,7 @@ extension GmailService: MessageGateway {
     func sendMail(input: MessageGatewayInput, progressHandler: ((Float) -> Void)?) async throws {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             guard let raw = GTLREncodeBase64(input.mime) else {
-                continuation.resume(throwing: GmailServiceError.messageEncode)
-                return
+                return continuation.resume(throwing: GmailServiceError.messageEncode)
             }
 
             self.progressHandler = progressHandler
@@ -32,10 +31,9 @@ extension GmailService: MessageGateway {
             gmailService.executeQuery(querySend) { [weak self] _, _, error in
                 self?.progressHandler = nil
                 if let error = error {
-                    continuation.resume(throwing: GmailServiceError.providerError(error))
-                } else {
-                    continuation.resume(returning: ())
+                    return continuation.resume(throwing: GmailServiceError.providerError(error))
                 }
+                return continuation.resume(returning: ())
             }
         }
     }

--- a/FlowCrypt/Functionality/Mail Provider/Message Gateway/Imap+send.swift
+++ b/FlowCrypt/Functionality/Mail Provider/Message Gateway/Imap+send.swift
@@ -8,17 +8,15 @@ extension Imap: MessageGateway {
     func sendMail(input: MessageGatewayInput, progressHandler: ((Float) -> Void)?) async throws {
         try await withCheckedThrowingContinuation { [weak smtpSess] (continuation: CheckedContinuation<Void, Error>) in
             guard let session = smtpSess else {
-                continuation.resume(returning: ())
-                return
+                return continuation.resume(returning: ())
             }
 
             session.sendOperation(with: input.mime)
                 .start { error in
                     if let error = error {
-                        continuation.resume(throwing: error)
-                    } else {
-                        continuation.resume(returning: ())
+                        return continuation.resume(throwing: error)
                     }
+                    return continuation.resume(returning: ())
                 }
         }
     }

--- a/FlowCrypt/Functionality/Mail Provider/Message Provider/Gmail+Message.swift
+++ b/FlowCrypt/Functionality/Mail Provider/Message Provider/Gmail+Message.swift
@@ -15,8 +15,7 @@ extension GmailService: MessageProvider {
                   progressHandler: ((MessageFetchState) -> Void)?) async throws -> Data {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Data, Error>) in
             guard let identifier = message.identifier.stringId else {
-                continuation.resume(throwing: GmailServiceError.missedMessageInfo("id"))
-                return
+                return continuation.resume(throwing: GmailServiceError.missedMessageInfo("id"))
             }
 
             Task {
@@ -29,26 +28,23 @@ extension GmailService: MessageProvider {
                 }
                 fetcher.beginFetch { data, error in
                     if let error = error {
-                        continuation.resume(throwing: GmailServiceError.providerError(error))
-                        return
+                        return continuation.resume(throwing: GmailServiceError.providerError(error))
                     }
 
                     guard let data = data,
                           let dictionary = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
                           let raw = dictionary["raw"] as? String
                     else {
-                        continuation.resume(throwing: GmailServiceError.missedMessageInfo("raw"))
-                        return
+                        return continuation.resume(throwing: GmailServiceError.missedMessageInfo("raw"))
                     }
 
                     progressHandler?(.decrypt)
 
                     guard let data = GTLRDecodeWebSafeBase64(raw) else {
-                        continuation.resume(throwing: GmailServiceError.missedMessageInfo("data"))
-                        return
+                        return continuation.resume(throwing: GmailServiceError.missedMessageInfo("data"))
                     }
 
-                    continuation.resume(returning: data)
+                    return continuation.resume(returning: data)
                 }
             }
         }
@@ -59,23 +55,20 @@ extension GmailService: MessageProvider {
             let query = createMessageQuery(identifier: identifier, format: kGTLRGmailFormatMetadata)
             self.gmailService.executeQuery(query) { _, data, error in
                 if let error = error {
-                    continuation.resume(throwing: GmailServiceError.providerError(error))
-                    return
+                    return continuation.resume(throwing: GmailServiceError.providerError(error))
                 }
 
                 guard let gmailMessage = data as? GTLRGmail_Message else {
-                    continuation.resume(throwing: AppErr.cast("GTLRGmail_Message"))
-                    return
+                    return continuation.resume(throwing: AppErr.cast("GTLRGmail_Message"))
                 }
 
                 guard let sizeEstimate = gmailMessage.sizeEstimate?.floatValue else {
-                    continuation.resume(throwing: GmailServiceError.missedMessageInfo("sizeEstimate"))
-                    return
+                    return continuation.resume(throwing: GmailServiceError.missedMessageInfo("sizeEstimate"))
                 }
 
                 // google returns smaller estimated size
                 let totalSize = sizeEstimate * Float(1.3)
-                continuation.resume(with: .success(totalSize))
+                return continuation.resume(with: .success(totalSize))
             }
         }
     }

--- a/FlowCrypt/Functionality/Mail Provider/MessageOperations Provider/Gmail+MessageOperations.swift
+++ b/FlowCrypt/Functionality/Mail Provider/MessageOperations Provider/Gmail+MessageOperations.swift
@@ -37,7 +37,7 @@ extension GmailService: MessageOperationsProvider {
                 if let error = error {
                     return continuation.resume(throwing: GmailServiceError.providerError(error))
                 }
-                continuation.resume(returning: ())
+                return continuation.resume(returning: ())
             }
         }
     }
@@ -71,9 +71,9 @@ extension GmailService: MessageOperationsProvider {
 
             self.gmailService.executeQuery(query) { _, _, error in
                 if let error = error {
-                    continuation.resume(throwing: GmailServiceError.providerError(error))
+                    return continuation.resume(throwing: GmailServiceError.providerError(error))
                 }
-                continuation.resume(returning: ())
+                return continuation.resume(returning: ())
             }
         }
     }

--- a/FlowCrypt/Functionality/Mail Provider/MessageOperations Provider/Imap+MessageOperations.swift
+++ b/FlowCrypt/Functionality/Mail Provider/MessageOperations Provider/Imap+MessageOperations.swift
@@ -28,9 +28,9 @@ extension Imap: MessageOperationsProvider {
                 )
                 .start { error in
                     if let error = error {
-                        continuation.resume(throwing: ImapError.providerError(error))
+                        return continuation.resume(throwing: ImapError.providerError(error))
                     } else {
-                        continuation.resume(returning: ())
+                        return continuation.resume(returning: ())
                     }
                 }
         }
@@ -63,9 +63,9 @@ extension Imap: MessageOperationsProvider {
                 )
                 .start { error in
                     if let error = error {
-                        continuation.resume(throwing: ImapError.providerError(error))
+                        return continuation.resume(throwing: ImapError.providerError(error))
                     } else {
-                        continuation.resume(returning: ())
+                        return continuation.resume(returning: ())
                     }
                 }
         }
@@ -93,9 +93,9 @@ extension Imap: MessageOperationsProvider {
                 .copyMessagesOperation(withFolder: folder, uids: MCOIndexSet(index: UInt64(id)), destFolder: destFolder)
                 .start { (error, _)in
                     if let error = error {
-                        continuation.resume(throwing: ImapError.providerError(error))
+                        return continuation.resume(throwing: ImapError.providerError(error))
                     } else {
-                        continuation.resume(returning: ())
+                        return continuation.resume(returning: ())
                     }
                 }
         }
@@ -130,9 +130,9 @@ extension Imap: MessageOperationsProvider {
                 )
                 .start { error in
                     if let error = error {
-                        continuation.resume(throwing: ImapError.providerError(error))
+                        return continuation.resume(throwing: ImapError.providerError(error))
                     } else {
-                        continuation.resume(returning: ())
+                        return continuation.resume(returning: ())
                     }
                 }
         }
@@ -148,9 +148,9 @@ extension Imap: MessageOperationsProvider {
                 .expungeOperation(folder)
                 .start { error in
                     if let error = error {
-                        continuation.resume(throwing: ImapError.providerError(error))
+                        return continuation.resume(throwing: ImapError.providerError(error))
                     } else {
-                        continuation.resume(returning: ())
+                        return continuation.resume(returning: ())
                     }
                 }
         }

--- a/FlowCrypt/Functionality/Mail Provider/MessagesList Provider/Gmail+MessagesList.swift
+++ b/FlowCrypt/Functionality/Mail Provider/MessagesList Provider/Gmail+MessagesList.swift
@@ -80,16 +80,13 @@ extension GmailService: DraftsListProvider {
         return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<GTLRGmail_ListDraftsResponse, Error>) in
             gmailService.executeQuery(query) { _, data, error in
                 if let error = error {
-                    continuation.resume(throwing: GmailServiceError.providerError(error))
-                    return
+                    return continuation.resume(throwing: GmailServiceError.providerError(error))
                 }
 
                 guard let messageList = data as? GTLRGmail_ListDraftsResponse else {
-                    continuation.resume(throwing: AppErr.cast("GTLRGmail_ListDraftsResponse"))
-                    return
+                    return continuation.resume(throwing: AppErr.cast("GTLRGmail_ListDraftsResponse"))
                 }
-
-                continuation.resume(returning: messageList)
+                return continuation.resume(returning: messageList)
             }
         }
     }
@@ -119,16 +116,14 @@ extension GmailService {
         return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<GTLRGmail_ListMessagesResponse, Error>) in
             gmailService.executeQuery(query) { _, data, error in
                 if let error = error {
-                    continuation.resume(throwing: GmailServiceError.providerError(error))
-                    return
+                    return continuation.resume(throwing: GmailServiceError.providerError(error))
                 }
 
                 guard let messageList = data as? GTLRGmail_ListMessagesResponse else {
-                    continuation.resume(throwing: AppErr.cast("GTLRGmail_ListMessagesResponse"))
-                    return
+                    return continuation.resume(throwing: AppErr.cast("GTLRGmail_ListMessagesResponse"))
                 }
 
-                continuation.resume(returning: messageList)
+                return continuation.resume(returning: messageList)
             }
         }
     }
@@ -139,19 +134,17 @@ extension GmailService {
         return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Message, Error>) in
             gmailService.executeQuery(query) { _, data, error in
                 if let error = error {
-                    continuation.resume(throwing: GmailServiceError.providerError(error))
-                    return
+                    return continuation.resume(throwing: GmailServiceError.providerError(error))
                 }
 
                 guard let gmailMessage = data as? GTLRGmail_Message else {
-                    continuation.resume(throwing: AppErr.cast("GTLRGmail_Message"))
-                    return
+                    return continuation.resume(throwing: AppErr.cast("GTLRGmail_Message"))
                 }
 
                 do {
-                    continuation.resume(returning: try Message(gmailMessage, draftIdentifier: draftIdentifier))
+                    return continuation.resume(returning: try Message(gmailMessage, draftIdentifier: draftIdentifier))
                 } catch {
-                    continuation.resume(throwing: error)
+                    return continuation.resume(throwing: error)
                 }
             }
         }

--- a/FlowCrypt/Functionality/Mail Provider/Threads/MessagesThreadOperationsProvider.swift
+++ b/FlowCrypt/Functionality/Mail Provider/Threads/MessagesThreadOperationsProvider.swift
@@ -91,9 +91,9 @@ extension GmailService: MessagesThreadOperationsProvider {
 
             self.gmailService.executeQuery(query) { _, _, error in
                 if let error = error {
-                    continuation.resume(throwing: GmailServiceError.providerError(error))
+                    return continuation.resume(throwing: GmailServiceError.providerError(error))
                 }
-                continuation.resume(returning: ())
+                return continuation.resume(returning: ())
             }
         }
     }

--- a/FlowCrypt/Functionality/Mail Provider/Threads/MessagesThreadProvider.swift
+++ b/FlowCrypt/Functionality/Mail Provider/Threads/MessagesThreadProvider.swift
@@ -55,7 +55,7 @@ extension GmailService: MessagesThreadProvider {
                 guard let threadsResponse = data as? GTLRGmail_ListThreadsResponse else {
                     return continuation.resume(throwing: AppErr.cast("GTLRGmail_ListThreadsResponse"))
                 }
-                continuation.resume(returning: threadsResponse)
+                return continuation.resume(returning: threadsResponse)
             }
         }
     }
@@ -91,7 +91,7 @@ extension GmailService: MessagesThreadProvider {
                     path: path,
                     messages: messages
                 )
-                continuation.resume(returning: result)
+                return continuation.resume(returning: result)
             }
         }
     }


### PR DESCRIPTION
This PR always adds a return before `continuation.resume` even if it's not needed there.

While it may look like an overkill, if we make this a convention, we will ensure to never run into the same bug again, and it will be easier to catch these bugs in PR reviews even without full context of the surrounding code. Missing return -> code smell, even if the code is otherwise correct.

close #966

----------------------------------

**Tests**:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
