### PR TITLE
extract app crash logs from simulator with appium test

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -12,9 +12,10 @@ auto_cancel:
 blocks:
   - name: Appium UI tests
     dependencies: []
-    run:
-      when: 'change_in(''/'', {exclude: [''/Core/package.json'', ''/Core/package-lock.json'']})'
-    execution_time_limit:
+    run: # don't run if the only thing that changed is Core deps
+      when: "change_in('/', {exclude: ['/Core/package.json', '/Core/package-lock.json']})"
+
+  execution_time_limit:
       minutes: 55
     task:
       secrets:
@@ -48,8 +49,8 @@ blocks:
             - artifact push job ~/Library/Logs/DiagnosticReports/FlowCrypt_*
   - name: TypeScript + Swift tests
     dependencies: []
-    run:
-      when: 'change_in(''/'', {exclude: [''/appium/package.json'', ''/appium/package-lock.json'']})'
+    run: # don't run if the only thing that changed is Appium test deps
+      when: "change_in('/', {exclude: ['/appium/package.json', '/appium/package-lock.json']})"
     execution_time_limit:
       minutes: 55
     task:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -15,7 +15,7 @@ blocks:
     run: # don't run if the only thing that changed is Core deps
       when: "change_in('/', {exclude: ['/Core/package.json', '/Core/package-lock.json']})"
 
-  execution_time_limit:
+    execution_time_limit:
       minutes: 55
     task:
       secrets:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -12,8 +12,8 @@ auto_cancel:
 blocks:
   - name: Appium UI tests
     dependencies: []
-    run: # don't run if the only thing that changed is Core deps
-      when: "change_in('/', {exclude: ['/Core/package.json', '/Core/package-lock.json']})"
+    run:
+      when: 'change_in(''/'', {exclude: [''/Core/package.json'', ''/Core/package-lock.json'']})'
     execution_time_limit:
       minutes: 55
     task:
@@ -43,10 +43,13 @@ blocks:
         always:
           commands:
             - artifact push job ~/git/flowcrypt-ios/appium/tmp
+        on_fail:
+          commands:
+            - artifact push job ~/Library/Logs/DiagnosticReports/FlowCrypt_*
   - name: TypeScript + Swift tests
     dependencies: []
-    run: # don't run if the only thing that changed is Appium test deps
-      when: "change_in('/', {exclude: ['/appium/package.json', '/appium/package-lock.json']})"
+    run:
+      when: 'change_in(''/'', {exclude: [''/appium/package.json'', ''/appium/package-lock.json'']})'
     execution_time_limit:
       minutes: 55
     task:
@@ -65,4 +68,3 @@ blocks:
           commands:
             - ( cd Core && cache restore core-npm && ../.custom-npm/node_modules/.bin/npm install && cache store core-npm node_modules && ../.custom-npm/node_modules/.bin/npm test )
             - bundle exec fastlane test
-

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -14,7 +14,6 @@ blocks:
     dependencies: []
     run: # don't run if the only thing that changed is Core deps
       when: "change_in('/', {exclude: ['/Core/package.json', '/Core/package-lock.json']})"
-
     execution_time_limit:
       minutes: 55
     task:


### PR DESCRIPTION
This PR allow to save crash logs if during execution we will face with bugs when app is crashing so we want to get logs and save time for developers in debugging problem

close #890 
