### PR TITLE
Remove only inbox label for archive operation

### DIFF
--- a/FlowCrypt/Functionality/Mail Provider/MessageOperations Provider/Gmail+MessageOperations.swift
+++ b/FlowCrypt/Functionality/Mail Provider/MessageOperations Provider/Gmail+MessageOperations.swift
@@ -48,6 +48,7 @@ extension GmailService: MessageOperationsProvider {
             labelsToRemove: message.labels
                 .filter(\.isLabel)
                 .map(\.type)
+                .filter { $0.isInbox }
         )
     }
 

--- a/FlowCrypt/Functionality/Mail Provider/MessagesList Provider/Model/MessageLabel.swift
+++ b/FlowCrypt/Functionality/Mail Provider/MessagesList Provider/Model/MessageLabel.swift
@@ -49,6 +49,15 @@ enum MessageLabelType: Equatable, Hashable {
     }
 }
 
+extension MessageLabelType {
+    var isInbox: Bool {
+        guard case .inbox = self else {
+            return false
+        }
+        return true
+    }
+}
+
 // MARK: - IMAP Flags
 extension MessageLabelType {
     // swiftlint:disable cyclomatic_complexity


### PR DESCRIPTION
This PR fix removing all labels for gmail archive operation

close #816

----------------------------------

**Tests**:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
