### PR TITLE
#1215 Fix Semaphore test reports

### DIFF
--- a/appium/config/wdio.shared.conf.js
+++ b/appium/config/wdio.shared.conf.js
@@ -27,6 +27,9 @@ exports.config = {
     'spec',
     ['junit', {
       outputDir: './tmp/test-results',
+      outputFileFormat: function (options) {
+        return `wdio-${options.cid}.xml`
+      }
     }],
     [video, {
       saveAllVideos: false,       // If true, also saves videos for successful test cases


### PR DESCRIPTION
This PR changes report files format from `.log` to `.xml` for Semaphore compatibility.

close #1215

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
