### PR TITLE
Fix text color for backup screen

### DIFF
--- a/FlowCrypt/Controllers/Settings/Backup/Backups Scene/BackupViewDecorator.swift
+++ b/FlowCrypt/Controllers/Settings/Backup/Backups Scene/BackupViewDecorator.swift
@@ -46,8 +46,8 @@ struct BackupViewDecorator: BackupViewDecoratorType {
             subtitle = "\n\n" + "backup_screen_not_found_description".localized
         }
 
-        let titleAttributedString = title.attributed(.bold(20), color: .textColor, alignment: .center)
-        let subtitleAttrinutedString = subtitle.attributed(.medium(14), color: .textColor, alignment: .center)
+        let titleAttributedString = title.attributed(.bold(18), color: .mainTextColor, alignment: .center)
+        let subtitleAttrinutedString = subtitle.attributed(.medium(14), color: .mainTextColor, alignment: .center)
         let result = NSMutableAttributedString(attributedString: titleAttributedString)
         result.append(subtitleAttrinutedString)
 


### PR DESCRIPTION
This PR fix text colors for backup screen

close #1014 

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

-----------------------------
<img src="https://user-images.githubusercontent.com/13693255/147268172-cf81bbd0-4722-43f4-b440-5fbc00424808.png"  width="400">

<img src="https://user-images.githubusercontent.com/13693255/147268176-7045f0a3-f3cf-45a3-a1b6-56845a6abd5f.png"  width="400">

<img src="https://user-images.githubusercontent.com/13693255/147268180-3890b150-4bf7-4250-b2df-302320c58e33.png"  width="400">
---

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
