### PR TITLE
Add use another account button to SetupInitialViewController

### DIFF
--- a/FlowCrypt/Common UI/CommonNodesInputs.swift
+++ b/FlowCrypt/Common UI/CommonNodesInputs.swift
@@ -10,39 +10,45 @@ import FlowCryptUI
 import UIKit
 
 extension TextCellNode {
-    static let loading: TextCellNode = .init(
-        input: .init(
-            backgroundColor: .backgroundColor,
-            title: "loading_title".localized + "...",
-            withSpinner: true,
-            size: CGSize(width: 44, height: 44)
+    static var loading: TextCellNode {
+        .init(
+            input: .init(
+                backgroundColor: .backgroundColor,
+                title: "loading_title".localized + "...",
+                withSpinner: true,
+                size: CGSize(width: 44, height: 44)
+            )
         )
-    )
+    }
 }
 
 extension ButtonCellNode.Input {
-    static let retry: ButtonCellNode.Input = .init(
-        title: "retry_title"
-            .localized
-            .attributed(.bold(16), color: .white, alignment: .center),
-        insets: UIEdgeInsets(top: 16, left: 24, bottom: 8, right: 24),
-        color: .main
-    )
+    static var retry: ButtonCellNode.Input {
+        .init(
+            title: "retry_title"
+                .localized
+                .attributed(.bold(16), color: .white, alignment: .center),
+            insets: UIEdgeInsets(top: 16, left: 24, bottom: 8, right: 24),
+            color: .main
+        )
+    }
 
-    static let chooseAnotherAccount: ButtonCellNode.Input = .init(
-        title: "setup_use_another"
-            .localized
-            .attributed(
-                .regular(15),
-                color: UIColor.colorFor(
-                    darkStyle: .white,
-                    lightStyle: .blueColor
+    static var chooseAnotherAccount: ButtonCellNode.Input {
+        .init(
+            title: "setup_use_another"
+                .localized
+                .attributed(
+                    .regular(15),
+                    color: UIColor.colorFor(
+                        darkStyle: .white,
+                        lightStyle: .blueColor
+                    ),
+                    alignment: .center
                 ),
-                alignment: .center
-            ),
-        insets: .side(8),
-        color: .backgroundColor
-    )
+            insets: .side(8),
+            color: .backgroundColor
+        )
+    }
 }
 
 extension CheckBoxTextNode.Input {

--- a/FlowCrypt/Controllers/Setup/SetupInitialViewController.swift
+++ b/FlowCrypt/Controllers/Setup/SetupInitialViewController.swift
@@ -36,7 +36,7 @@ final class SetupInitialViewController: TableNodeViewController {
             case .searchingKeyBackupsInInbox:
                 return 2
             case .error:
-                return 3
+                return 4
             case .noKeyBackupsInInbox:
                 return Parts.allCases.count
             }
@@ -306,7 +306,7 @@ extension SetupInitialViewController {
             return TextCellNode(
                 input: .init(
                     backgroundColor: .backgroundColor,
-                    title: error.localizedDescription,
+                    title: error.errorMessage,
                     withSpinner: false,
                     size: CGSize(width: 200, height: 200)
                 )
@@ -314,6 +314,10 @@ extension SetupInitialViewController {
         case 2:
             return ButtonCellNode(input: .retry) { [weak self] in
                 self?.state = .searchingKeyBackupsInInbox
+            }
+        case 3:
+            return ButtonCellNode(input: .chooseAnotherAccount) { [weak self] in
+                self?.signOut()
             }
         default:
             return ASCellNode()
@@ -332,6 +336,7 @@ extension SetupInitialViewController {
         let viewController = SetupGenerateKeyViewController(appContext: appContext, user: user)
         navigationController?.pushViewController(viewController, animated: true)
     }
+
     private func proceedToSetupWithEKMKeys(keys: [KeyDetails]) {
         let viewController = SetupEKMKeyViewController(appContext: appContext, user: user, keys: keys)
         navigationController?.pushViewController(viewController, animated: true)

--- a/FlowCrypt/Extensions/UIColorExtensions.swift
+++ b/FlowCrypt/Extensions/UIColorExtensions.swift
@@ -20,7 +20,7 @@ public extension UIColor {
             lightStyle: .black
         )
     }
-    
+
     static var warningColor: UIColor {
         UIColor(r: 194, g: 126, b: 35)
     }

--- a/FlowCrypt/Functionality/Mail Provider/Imap/ImapError.swift
+++ b/FlowCrypt/Functionality/Mail Provider/Imap/ImapError.swift
@@ -13,3 +13,16 @@ enum ImapError: Error {
     case providerError(Error)
     case missedMessageInfo(String)
 }
+
+extension ImapError: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case .noSession:
+            return "imap_error_no_session".localized
+        case .providerError(let error):
+            return "imap_error_provider".localizeWithArguments(error.localizedDescription)
+        case .missedMessageInfo(let message):
+            return "imap_error_msg_info".localizeWithArguments(message)
+        }
+    }
+}

--- a/FlowCrypt/Resources/en.lproj/Localizable.strings
+++ b/FlowCrypt/Resources/en.lproj/Localizable.strings
@@ -289,3 +289,8 @@
 
 // Attachments details
 "no_preview_avalable" = "No preview available";
+
+// ImapError
+"imap_error_no_session" = "Session isn't established";
+"imap_error_provider" = "Provider error %@";
+"imap_error_msg_info" = "Can't parse message without \"%@\"";


### PR DESCRIPTION
This PR adds "use another account" button in case of error on `SetupInitialViewController`

close #1241

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)
- Difficult to test (Do we have setup for UI tests for error flows?)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
