### PR TITLE
#1222 Add id tokens refresh on expiry

### DIFF
--- a/FlowCrypt/Functionality/Services/GoogleUserService.swift
+++ b/FlowCrypt/Functionality/Services/GoogleUserService.swift
@@ -47,8 +47,8 @@ struct IdToken: Codable {
 }
 
 extension IdToken {
-    var isExpired: Bool {
-        Double(exp) < Date().timeIntervalSince1970
+    var expiryDuration: Double {
+        Date(timeIntervalSince1970: Double(exp)).timeIntervalSinceNow
     }
 }
 
@@ -254,12 +254,12 @@ extension GoogleUserService {
 
 // MARK: - Tokens
 extension GoogleUserService {
-    func getCachedOrRefreshedIdToken() async throws -> String {
+    func getCachedOrRefreshedIdToken(minExpiryDuration: Double = 0) async throws -> String {
         guard let idToken = idToken else { throw(IdTokenError.missingToken) }
 
         let decodedToken = try decode(idToken: idToken)
 
-        guard !decodedToken.isExpired else {
+        guard decodedToken.expiryDuration > minExpiryDuration else {
             let (_, updatedToken) = try await performTokenRefresh()
             return updatedToken
         }


### PR DESCRIPTION
This PR adds `minExpiryDuration` parameter for fetching id tokens.

close #1222 

----------------------------------

**Tests** _(delete all except exactly one)_:
- Difficult to test (explain why) - tokens are fetched from Google API

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
