### PR TITLE
#1285 fix sanitize-html build

### DIFF
--- a/Core/source/platform/xss.ts
+++ b/Core/source/platform/xss.ts
@@ -6,7 +6,7 @@ type Transformer = (tagName: string, attribs: Attributes) => Tag;
 
 export type SanitizeImgHandling = 'IMG-DEL' | 'IMG-KEEP' | 'IMG-TO-LINK';
 
-declare const dereq_html_sanitize: (dirty: string, opts?: {
+declare const dereq_sanitize_html: (dirty: string, opts?: {
   allowedTags?: string[],
   selfClosing?: string[],
   exclusiveFilter?: (frame: { tag: string, attribs: Attributes, text: string, tagPosition: number }) => boolean,
@@ -47,7 +47,7 @@ export class Xss {
   public static htmlSanitizeKeepBasicTags = (dirtyHtml: string, imgToLink?: SanitizeImgHandling): string => {
     const imgContentReplaceable = `IMG_ICON_${Str.sloppyRandom()}`;
     let remoteContentReplacedWithLink = false;
-    let cleanHtml = dereq_html_sanitize(dirtyHtml, {
+    let cleanHtml = dereq_sanitize_html(dirtyHtml, {
       allowedTags: Xss.ALLOWED_BASIC_TAGS,
       allowedAttributes: Xss.ALLOWED_ATTRS,
       allowedSchemes: Xss.ALLOWED_SCHEMES,
@@ -85,7 +85,7 @@ export class Xss {
     if (remoteContentReplacedWithLink) {
       cleanHtml = `<font size="-1" color="#31a217" face="monospace">[remote content blocked for your privacy]</font><br /><br />${cleanHtml}`;
       // clean it one more time in case something bad slipped in
-      cleanHtml = dereq_html_sanitize(cleanHtml, { allowedTags: Xss.ALLOWED_BASIC_TAGS, allowedAttributes: Xss.ALLOWED_ATTRS, allowedSchemes: Xss.ALLOWED_SCHEMES });
+      cleanHtml = dereq_sanitize_html(cleanHtml, { allowedTags: Xss.ALLOWED_BASIC_TAGS, allowedAttributes: Xss.ALLOWED_ATTRS, allowedSchemes: Xss.ALLOWED_SCHEMES });
     }
     cleanHtml = cleanHtml.replace(new RegExp(imgContentReplaceable, 'g'), `<font color="#D14836" face="monospace">[img]</font>`);
     return cleanHtml;
@@ -106,7 +106,7 @@ export class Xss {
     let text = html.split(br).join('\n').split(blockStart).filter(v => !!v).join('\n').split(blockEnd).filter(v => !!v).join('\n');
     text = text.replace(/\n{2,}/g, '\n\n');
     // not all tags were removed above. Remove all remaining tags
-    text = dereq_html_sanitize(text, {
+    text = dereq_sanitize_html(text, {
       allowedTags: ['img', 'span'],
       allowedAttributes: { img: ['src'] },
       allowedSchemes: Xss.ALLOWED_SCHEMES,
@@ -116,7 +116,7 @@ export class Xss {
         },
       }
     });
-    text = dereq_html_sanitize(text, { allowedTags: [] }); // clean it one more time to replace leftover spans with their text
+    text = dereq_sanitize_html(text, { allowedTags: [] }); // clean it one more time to replace leftover spans with their text
     text = text.trim();
     if (outputNl !== '\n') {
       text = text.replace(/\n/g, outputNl);

--- a/Core/source/test.ts
+++ b/Core/source/test.ts
@@ -3,7 +3,7 @@
 'use strict';
 
 // @ts-ignore - this way we can test the Xss class directly as well
-global.dereq_html_sanitize = require("sanitize-html");
+global.dereq_sanitize_html = require("sanitize-html");
 // @ts-ignore - this way we can test ISO-2201-JP encoding
 global.dereq_encoding_japanese = require("encoding-japanese");
 (global as any)["emailjs-mime-builder"] = require('../../source/lib/emailjs/emailjs-mime-builder');

--- a/Core/tooling/fix-bundles.js
+++ b/Core/tooling/fix-bundles.js
@@ -26,7 +26,7 @@ for (const filename of fs.readdirSync(bundleRawDir)) {
 // copy raw to flowcrypt-bundle
 fs.copyFileSync(`${bundleRawDir}/entrypoint-bare.js`, `${bundleDir}/entrypoint-bare-bundle.js`);
 
-const sanitizeHtmlDist = './node_modules/sanitize-html/index.js';
+const sanitizeHtmlDist = `${bundleRawDir}/sanitize-html.js`;
 
 // copy wip to html-sanitize-bundle
 fs.writeFileSync(

--- a/Core/tooling/fix-bundles.js
+++ b/Core/tooling/fix-bundles.js
@@ -26,12 +26,12 @@ for (const filename of fs.readdirSync(bundleRawDir)) {
 // copy raw to flowcrypt-bundle
 fs.copyFileSync(`${bundleRawDir}/entrypoint-bare.js`, `${bundleDir}/entrypoint-bare-bundle.js`);
 
-const sanitizeHtmlDist = `${bundleRawDir}/sanitize-html.js`;
+const sanitizeHtmlDist = `${bundleWipDir}/sanitize-html.js`;
 
 // copy wip to html-sanitize-bundle
 fs.writeFileSync(
   `${bundleDir}/bare-html-sanitize-bundle.js`,
-  `${fs.readFileSync(sanitizeHtmlDist).toString()}\nconst dereq_html_sanitize = window.sanitizeHtml;\n`
+  fs.readFileSync(sanitizeHtmlDist).toString()
 );
 
 // copy zxcvbn, only used for bare (iOS) because zxcvbn-ios is not well maintained: https://github.com/dropbox/zxcvbn-ios/issues

--- a/Core/webpack.bare.config.js
+++ b/Core/webpack.bare.config.js
@@ -5,7 +5,8 @@ module.exports = {
   entry: {
     'entrypoint-bare': './build/ts/entrypoint-bare.js',
     'bare-asn1': './node_modules/asn1.js/lib/asn1.js',
-    'bare-encoding-japanese': './node_modules/encoding-japanese/encoding.js'
+    'bare-encoding-japanese': './node_modules/encoding-japanese/encoding.js',
+    'sanitize-html': './node_modules/sanitize-html/index.js'
   },
   output: {
     path: __dirname + '/build/bundles/raw',

--- a/FlowCrypt/Core/Core.swift
+++ b/FlowCrypt/Core/Core.swift
@@ -204,8 +204,13 @@ actor Core: KeyDecrypter, KeyParser, CoreComposeMessageType {
         context?.setObject(CoreHost(), forKeyedSubscript: "coreHost" as (NSCopying & NSObjectProtocol))
         context!.exceptionHandler = { _, exception in
             guard let exception = exception else { return }
+
+            let line = exception.objectForKeyedSubscript("line").toString()
+            let column = exception.objectForKeyedSubscript("column").toString()
+            let location = [line, column].compactMap { $0 }.joined(separator: ":")
+
             let logger = Logger.nested(in: Self.self, with: "Js")
-            logger.logWarning("\(exception)")
+            logger.logWarning("\(exception), \(location)")
         }
         context!.evaluateScript("const APP_VERSION = 'iOS 0.2';")
         context!.evaluateScript(jsFileSrc)

--- a/FlowCrypt/Core/CoreHost.swift
+++ b/FlowCrypt/Core/CoreHost.swift
@@ -23,6 +23,7 @@ import SwiftyRSA // for rsa
     func clearTimeout(_ identifier: String)
 
     func handleCallback(_ endpointKey: String, _ string: String, _ data: [UInt8])
+    func log(_ message: String)
 }
 
 var timers = [String: Timer]()
@@ -123,6 +124,10 @@ final class CoreHost: NSObject, CoreHostExports {
         Task {
             await Core.shared.handleCallbackResult(callbackId: callbackId, json: string, data: data)
         }
+    }
+
+    func log(_ message: String) {
+        Logger.logDebug(message)
     }
 
     @objc func callJsCb(_ timer: Timer) {


### PR DESCRIPTION
This PR fixes errors when using `sanitize-html` through iOS `Core` functionality.

close #1285

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes) - we already have `testEndToEnd` test which fails when any error occurs during html sanitize.

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
