### PR TITLE
#1284 fix inbox pagination after loading all messages

### DIFF
--- a/FlowCrypt/Controllers/Inbox/InboxViewController.swift
+++ b/FlowCrypt/Controllers/Inbox/InboxViewController.swift
@@ -228,11 +228,18 @@ extension InboxViewController {
         case .idle:
             fetchAndRenderEmails(context)
         case let .fetched(.byNumber(total)):
-            if inboxInput.count != total {
-                loadMore(context)
+            guard inboxInput.count != total else {
+                context?.completeBatchFetching(true)
+                return
             }
+
+            loadMore(context)
         case let .fetched(.byNextPage(token)):
-            guard token != nil else { return }
+            guard token != nil else {
+                context?.completeBatchFetching(true)
+                return
+            }
+
             loadMore(context)
         case .empty:
             fetchAndRenderEmails(context)


### PR DESCRIPTION
This PR fixes inbox pagination after loading all messages/threads.

close #1284

----------------------------------

**Tests** _(delete all except exactly one)_:
- Difficult to test (explain why) - there is no easy way to calculate how many messages were loaded in appium, can be done in separate task if such test is needed.

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
