### PR TITLE
Show file name extension when saving

### DIFF
--- a/FlowCrypt/Common UI/AttachmentManager.swift
+++ b/FlowCrypt/Common UI/AttachmentManager.swift
@@ -46,6 +46,7 @@ final class AttachmentManager: NSObject {
     @MainActor
     private func openDocumentsController(from url: URL) {
         let documentController = UIDocumentPickerViewController(forExporting: [url])
+        documentController.shouldShowFileExtensions = true
         documentController.delegate = self
         present(documentController, animated: true, completion: nil)
     }

--- a/FlowCrypt/Controllers/Attachment/AttachmentViewController.swift
+++ b/FlowCrypt/Controllers/Attachment/AttachmentViewController.swift
@@ -52,7 +52,7 @@ final class AttachmentViewController: UIViewController {
         return textView
     }()
 
-    private let errorLabel: UILabel = {
+    private lazy var errorLabel: UILabel = {
         let label = UILabel()
         label.textAlignment = .center
         label.text = "no_preview_avalable".localized
@@ -62,7 +62,7 @@ final class AttachmentViewController: UIViewController {
         return label
     }()
 
-    private var encodedContentRules: String {
+    private let encodedContentRules: String =
         """
         [{
             "trigger": {
@@ -73,7 +73,6 @@ final class AttachmentViewController: UIViewController {
             }
         }]
         """
-    }
 
     private var isNavigated = false
     private var didLayoutSubviews = false
@@ -122,7 +121,9 @@ final class AttachmentViewController: UIViewController {
                 NavigationBarItemsView.Input(
                     image: image?.tinted(.gray),
                     accessibilityId: "aid-save-attachment-to-device",
-                    onTap: { [weak self] in self?.downloadAttachment() }
+                    onTap: { [weak self] in
+                        self?.downloadAttachment()
+                    }
                 )
             ]
         )

--- a/FlowCrypt/Functionality/FilesManager/FilesManager.swift
+++ b/FlowCrypt/Functionality/FilesManager/FilesManager.swift
@@ -14,11 +14,21 @@ protocol FileType {
 }
 
 extension FileType {
-    var size: Int { data.count }
+    var size: Int {
+        data.count
+    }
     var formattedSize: String {
         ByteCountFormatter().string(fromByteCount: Int64(size))
     }
-    var type: String { name.mimeType }
+    var type: String {
+        name.mimeType
+    }
+    var fileName: String {
+        guard let sufix = name.components(separatedBy: ".").last else {
+            return name
+        }
+        return name + "." + sufix
+    }
 }
 
 protocol FilesManagerPresenter {
@@ -47,7 +57,8 @@ final class FilesManager {
 
 extension FilesManager: FilesManagerType {
     func save(file: FileType) async throws -> URL {
-        let url = self.documentsDirectoryURL.appendingPathComponent(file.name)
+        let url = self.documentsDirectoryURL.appendingPathComponent(file.fileName)
+
         return try await withCheckedThrowingContinuation { continuation in
             queue.async {
                 do {


### PR DESCRIPTION
This PR add file name extension to `UIDocumentPickerViewController` when saving
<img src="https://user-images.githubusercontent.com/13693255/151389652-8cb66766-4ba3-45d5-8f9a-d84f0ba46058.jpg" width = "300"/>
<img src="https://user-images.githubusercontent.com/13693255/151389667-4127bfe4-5448-4836-934e-2b8b8b33b3c6.jpg" width = "300"/>
<img src="https://user-images.githubusercontent.com/13693255/151389669-de122238-3387-4a85-83cd-80cd0b33e7f1.jpg" width = "300"/>

close #901 
----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
