### PR TITLE
added new spec for checking user color after removing pubkey for it

### DIFF
--- a/appium/tests/helpers/PublicKeyHelper.ts
+++ b/appium/tests/helpers/PublicKeyHelper.ts
@@ -35,6 +35,32 @@ class PublicKeyHelper {
    await PublicKeyDetailsScreen.checkSignatureDateValue(signatureDate);
    await PublicKeyDetailsScreen.checkFingerPrintsValue(fingerprintsValue);
  }
+ static addRecipientAndCheckFetchedKey = async (userName: string, userEmail: string ) => {
+   // Add first contact
+   await MailFolderScreen.clickCreateEmail();
+   await NewMessageScreen.setAddRecipientByName(userName, userEmail);
+   await NewMessageScreen.checkAddedRecipientColor(userEmail, 0, 'green');
+   await NewMessageScreen.clickBackButton();
+
+   // Go to Contacts screen
+   await MenuBarScreen.clickMenuIcon();
+   await MenuBarScreen.checkUserEmail();
+
+   await MenuBarScreen.clickSettingsButton();
+   await SettingsScreen.checkSettingsScreen();
+   await SettingsScreen.clickOnSettingItem('Contacts');
+
+   await ContactScreen.checkContactScreen();
+   await ContactScreen.checkContact(userEmail);
+
+   await ContactScreen.clickOnContact(userEmail);
+   await ContactPublicKeyScreen.checkPgpUserId(userEmail);
+   await ContactPublicKeyScreen.checkPublicKeyDetailsNotEmpty();
+   await ContactPublicKeyScreen.clickOnFingerPrint();
+
+   await PublicKeyDetailsScreen.checkPublicKeyDetailsScreen();
+   await PublicKeyDetailsScreen.checkPublicKeyNotEmpty();
+ }
 }
 
 export default PublicKeyHelper;

--- a/appium/tests/screenobjects/contact-public-key.screen.ts
+++ b/appium/tests/screenobjects/contact-public-key.screen.ts
@@ -68,6 +68,15 @@ class ContactPublicKeyScreen extends BaseScreen {
     expect(await (await this.expiresValue).getAttribute('value')).toBeTruthy();
   }
 
+  checkPublicKeyDetailsNotDisplayed = async () => {
+    await ElementHelper.waitElementInvisible(await this.fingerPrintLabel);
+    await ElementHelper.waitElementInvisible(await this.fingerPrintValue);
+    await ElementHelper.waitElementInvisible(await this.createdLabel);
+    await ElementHelper.waitElementInvisible(await this.createdValue);
+    await ElementHelper.waitElementInvisible(await this.expiresLabel);
+    await ElementHelper.waitElementInvisible(await this.expiresValue);
+  }
+
   checkPgpUserId = async (email: string) => {
     await (await this.trashButton).waitForDisplayed();
     await (await this.pgpUserIdLabel).waitForDisplayed();

--- a/appium/tests/screenobjects/contacts.screen.ts
+++ b/appium/tests/screenobjects/contacts.screen.ts
@@ -5,6 +5,7 @@ const SELECTORS = {
   CONTACTS_HEADER: '-ios class chain:**/XCUIElementTypeStaticText[`label == "Contacts"`]',
   BACK_BUTTON: '~aid-back-button',
   EMPTY_CONTACTS_LIST: '~Empty list',
+  NO_PUBLIC_KEY_LABEL: '~(No public keys)'
 };
 
 class ContactsScreen extends BaseScreen {
@@ -22,6 +23,10 @@ class ContactsScreen extends BaseScreen {
 
   get emptyContactsList() {
     return $(SELECTORS.EMPTY_CONTACTS_LIST);
+  }
+
+  get noPublicKeyLabel() {
+    return $(SELECTORS.NO_PUBLIC_KEY_LABEL);
   }
 
   contactName = async (name: string) => {
@@ -43,6 +48,11 @@ class ContactsScreen extends BaseScreen {
   checkContact = async (name: string) => {
     const element = await this.contactName(name);
     await element.waitForDisplayed();
+  }
+
+  checkContactWithoutPubKey = async (name: string) => {
+    await this.checkContact(name);
+    await (await this.noPublicKeyLabel).waitForDisplayed();
   }
 
   clickOnContact = async (name: string) => {

--- a/appium/tests/screenobjects/public-key-details.screen.ts
+++ b/appium/tests/screenobjects/public-key-details.screen.ts
@@ -108,6 +108,9 @@ class PublicKeyDetailsScreen extends BaseScreen {
     await ElementHelper.waitAndClick(await this.backButton);
   }
 
+  clickTrashButton = async () => {
+    await ElementHelper.waitAndClick(await this.trashButton);
+  }
 }
 
 export default new PublicKeyDetailsScreen();

--- a/appium/tests/specs/live/composeEmail/CheckRecipientColorAfterRemovingPubKey.spec.ts
+++ b/appium/tests/specs/live/composeEmail/CheckRecipientColorAfterRemovingPubKey.spec.ts
@@ -1,0 +1,89 @@
+import {
+  SplashScreen,
+  SetupKeyScreen,
+  MailFolderScreen,
+  NewMessageScreen,
+  ContactScreen,
+  ContactPublicKeyScreen,
+  SettingsScreen,
+  MenuBarScreen,
+  PublicKeyDetailsScreen
+} from '../../../screenobjects/all-screens';
+
+import { CommonData } from '../../../data';
+
+describe('COMPOSE EMAIL: ', () => {
+
+  it('check recipient color after removing public key from settings', async () => {
+
+    const contactEmail = CommonData.contact.email;
+    const contactName = CommonData.contact.name;
+
+    await SplashScreen.login();
+    await SetupKeyScreen.setPassPhrase();
+    await MailFolderScreen.checkInboxScreen();
+
+    // Add first contact
+    await MailFolderScreen.clickCreateEmail();
+    await NewMessageScreen.setAddRecipientByName(contactName, contactEmail);
+    await NewMessageScreen.checkAddedRecipientColor(contactEmail, 0, 'green');
+    await NewMessageScreen.clickBackButton();
+
+    // Go to Contacts screen
+    await MenuBarScreen.clickMenuIcon();
+    await MenuBarScreen.checkUserEmail();
+
+    await MenuBarScreen.clickSettingsButton();
+    await SettingsScreen.checkSettingsScreen();
+    await SettingsScreen.clickOnSettingItem('Contacts');
+
+    await ContactScreen.checkContactScreen();
+    await ContactScreen.checkContact(contactEmail);
+
+    await ContactScreen.clickOnContact(contactEmail);
+    await ContactPublicKeyScreen.checkPgpUserId(contactEmail);
+    await ContactPublicKeyScreen.checkPublicKeyDetailsNotEmpty();
+    await ContactPublicKeyScreen.clickOnFingerPrint();
+
+    await PublicKeyDetailsScreen.checkPublicKeyDetailsScreen();
+    await PublicKeyDetailsScreen.checkPublicKeyNotEmpty();
+
+    await PublicKeyDetailsScreen.clickTrashButton();
+    await ContactPublicKeyScreen.checkPgpUserId(contactEmail);
+    await ContactPublicKeyScreen.checkPublicKeyDetailsNotDisplayed();
+    await ContactPublicKeyScreen.clickBackButton();
+
+    await ContactScreen.checkContactWithoutPubKey(contactEmail);
+    await ContactScreen.clickBackButton();
+    await SettingsScreen.checkSettingsScreen();
+
+    await MenuBarScreen.clickMenuIcon();
+    await MenuBarScreen.checkUserEmail();
+    await MenuBarScreen.clickInboxButton();
+    await MailFolderScreen.checkInboxScreen();
+
+    await MailFolderScreen.clickCreateEmail();
+    await NewMessageScreen.setAddRecipientByName(contactName, contactEmail);
+    await NewMessageScreen.checkAddedRecipientColor(contactEmail, 0, 'green');
+    await NewMessageScreen.clickBackButton();
+
+    // Go to Contacts screen
+    await MenuBarScreen.clickMenuIcon();
+    await MenuBarScreen.checkUserEmail();
+
+    await MenuBarScreen.clickSettingsButton();
+    await SettingsScreen.checkSettingsScreen();
+    await SettingsScreen.clickOnSettingItem('Contacts');
+
+    await ContactScreen.checkContactScreen();
+    await ContactScreen.checkContact(contactEmail);
+
+    await ContactScreen.clickOnContact(contactEmail);
+    await ContactPublicKeyScreen.checkPgpUserId(contactEmail);
+    await ContactPublicKeyScreen.checkPublicKeyDetailsNotEmpty();
+    await ContactPublicKeyScreen.clickOnFingerPrint();
+
+    await PublicKeyDetailsScreen.checkPublicKeyDetailsScreen();
+    await PublicKeyDetailsScreen.checkPublicKeyNotEmpty();
+  });
+});

--- a/appium/tests/specs/live/composeEmail/CheckRecipientColorAfterRemovingPubKey.spec.ts
+++ b/appium/tests/specs/live/composeEmail/CheckRecipientColorAfterRemovingPubKey.spec.ts
@@ -2,7 +2,6 @@ import {
   SplashScreen,
   SetupKeyScreen,
   MailFolderScreen,
-  NewMessageScreen,
   ContactScreen,
   ContactPublicKeyScreen,
   SettingsScreen,
@@ -11,6 +10,7 @@ import {
 } from '../../../screenobjects/all-screens';
 
 import { CommonData } from '../../../data';
+import PublicKeyHelper from "../../../helpers/PublicKeyHelper";
 
 describe('COMPOSE EMAIL: ', () => {
 
@@ -23,30 +23,7 @@ describe('COMPOSE EMAIL: ', () => {
     await SetupKeyScreen.setPassPhrase();
     await MailFolderScreen.checkInboxScreen();
 
-    // Add first contact
-    await MailFolderScreen.clickCreateEmail();
-    await NewMessageScreen.setAddRecipientByName(contactName, contactEmail);
-    await NewMessageScreen.checkAddedRecipientColor(contactEmail, 0, 'green');
-    await NewMessageScreen.clickBackButton();
-
-    // Go to Contacts screen
-    await MenuBarScreen.clickMenuIcon();
-    await MenuBarScreen.checkUserEmail();
-
-    await MenuBarScreen.clickSettingsButton();
-    await SettingsScreen.checkSettingsScreen();
-    await SettingsScreen.clickOnSettingItem('Contacts');
-
-    await ContactScreen.checkContactScreen();
-    await ContactScreen.checkContact(contactEmail);
-
-    await ContactScreen.clickOnContact(contactEmail);
-    await ContactPublicKeyScreen.checkPgpUserId(contactEmail);
-    await ContactPublicKeyScreen.checkPublicKeyDetailsNotEmpty();
-    await ContactPublicKeyScreen.clickOnFingerPrint();
-
-    await PublicKeyDetailsScreen.checkPublicKeyDetailsScreen();
-    await PublicKeyDetailsScreen.checkPublicKeyNotEmpty();
+    await PublicKeyHelper.addRecipientAndCheckFetchedKey(contactName, contactEmail);
 
     await PublicKeyDetailsScreen.clickTrashButton();
     await ContactPublicKeyScreen.checkPgpUserId(contactEmail);
@@ -62,28 +39,6 @@ describe('COMPOSE EMAIL: ', () => {
     await MenuBarScreen.clickInboxButton();
     await MailFolderScreen.checkInboxScreen();
 
-    await MailFolderScreen.clickCreateEmail();
-    await NewMessageScreen.setAddRecipientByName(contactName, contactEmail);
-    await NewMessageScreen.checkAddedRecipientColor(contactEmail, 0, 'green');
-    await NewMessageScreen.clickBackButton();
-
-    // Go to Contacts screen
-    await MenuBarScreen.clickMenuIcon();
-    await MenuBarScreen.checkUserEmail();
-
-    await MenuBarScreen.clickSettingsButton();
-    await SettingsScreen.checkSettingsScreen();
-    await SettingsScreen.clickOnSettingItem('Contacts');
-
-    await ContactScreen.checkContactScreen();
-    await ContactScreen.checkContact(contactEmail);
-
-    await ContactScreen.clickOnContact(contactEmail);
-    await ContactPublicKeyScreen.checkPgpUserId(contactEmail);
-    await ContactPublicKeyScreen.checkPublicKeyDetailsNotEmpty();
-    await ContactPublicKeyScreen.clickOnFingerPrint();
-
-    await PublicKeyDetailsScreen.checkPublicKeyDetailsScreen();
-    await PublicKeyDetailsScreen.checkPublicKeyNotEmpty();
+    await PublicKeyHelper.addRecipientAndCheckFetchedKey(contactName, contactEmail);
   });
 });


### PR DESCRIPTION
This PR contains new spec for checking user color on compose email after removing pubkey for it, and checking pubkey after compose for contact with deleted pubkey

close #1353 


----------------------------------

**Tests** _
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
