### PR TITLE
added new spec for checking inbox pagination after loading all messages

### DIFF
--- a/FlowCrypt/Controllers/Inbox/InboxViewController.swift
+++ b/FlowCrypt/Controllers/Inbox/InboxViewController.swift
@@ -100,6 +100,7 @@ extension InboxViewController {
             $0.delegate = self
             $0.dataSource = self
             $0.leadingScreensForBatching = 1
+            $0.accessibilityIdentifier = "aid-inbox-list"
             $0.view.refreshControl = refreshControl
             node.addSubnode($0)
         }

--- a/appium/tests/helpers/MailFolderHelper.ts
+++ b/appium/tests/helpers/MailFolderHelper.ts
@@ -4,11 +4,11 @@ import MailFolderScreen from "../screenobjects/mail-folder.screen";
 class MailFolderHelper {
 
   static checkPagination = async (subject: string) => {
-    let emailsCountBeforeScroll = await MailFolderScreen.getEmailCount();
+    const emailsCountBeforeScroll = await MailFolderScreen.getEmailCount();
     await MailFolderScreen.scrollDownToEmail(subject);
     expect(emailsCountBeforeScroll).toEqual(40); //Should be changed to 20 when https://github.com/FlowCrypt/flowcrypt-ios/issues/1366 is fixed
 
-    let emailsCountAfterScroll = await MailFolderScreen.getEmailCount();
+    const emailsCountAfterScroll = await MailFolderScreen.getEmailCount();
     expect(emailsCountBeforeScroll).toBeLessThan(emailsCountAfterScroll);
   }
 }

--- a/appium/tests/helpers/MailFolderHelper.ts
+++ b/appium/tests/helpers/MailFolderHelper.ts
@@ -1,0 +1,15 @@
+import MailFolderScreen from "../screenobjects/mail-folder.screen";
+
+
+class MailFolderHelper {
+
+  static checkPagination = async (subject: string) => {
+    let emailsCountBeforeScroll = await MailFolderScreen.getEmailCount();
+    await MailFolderScreen.scrollDownToEmail(subject);
+    expect(emailsCountBeforeScroll).toEqual(40); //Should be changed to 20 when https://github.com/FlowCrypt/flowcrypt-ios/issues/1366 is fixed
+
+    let emailsCountAfterScroll = await MailFolderScreen.getEmailCount();
+    expect(emailsCountBeforeScroll).toBeLessThan(emailsCountAfterScroll);
+  }
+}
+export default MailFolderHelper;

--- a/appium/tests/helpers/TouchHelper.ts
+++ b/appium/tests/helpers/TouchHelper.ts
@@ -53,5 +53,28 @@ class TouchHelper {
     }
     throw new Error(`Element ${JSON.stringify(element.selector)} not displayed after scroll`);
   }
+
+  static scrollUpToElement = async (element: WebdriverIO.Element) => {
+    const { width, height } = await driver.getWindowSize();
+    const anchor = width / 2;
+    const startPoint = height * 0.15;
+    const endPoint = height * 0.75;
+
+    // this wait can be later replaced by waiting for loader to go away before scrolling
+    await browser.pause(1000); // make sure contents are loaded first, so we don't scroll too early
+    for(let i = 0; i < 15; i++) {
+      if (await element.isDisplayed()) {
+       return;
+      }
+      await driver.touchPerform([
+        {action: 'press', options: {x: anchor, y: startPoint}},
+        {action: 'wait', options: {ms: 100}},
+        {action: 'moveTo', options: {x: anchor, y: endPoint}},
+        {action: 'release', options: {}},
+      ]);
+      await browser.pause(1000); // due to scroll action which takes about second
+    }
+    throw new Error(`Element ${JSON.stringify(element.selector)} not displayed after scroll`);
+  }
 }
 export default TouchHelper;

--- a/appium/tests/screenobjects/mail-folder.screen.ts
+++ b/appium/tests/screenobjects/mail-folder.screen.ts
@@ -10,7 +10,7 @@ const SELECTORS = {
   SEARCH_ICON: '~search icn',
   HELP_ICON: '~help icn',
   SEARCH_FIELD: '~searchAllEmailField',
-  INBOX_LIST: '~aid-inbox-list',
+  INBOX_LIST: '-ios class chain:**/XCUIElementTypeOther/XCUIElementTypeTable[2]/XCUIElementTypeCell',
 };
 
 class MailFolderScreen extends BaseScreen {

--- a/appium/tests/screenobjects/mail-folder.screen.ts
+++ b/appium/tests/screenobjects/mail-folder.screen.ts
@@ -10,7 +10,7 @@ const SELECTORS = {
   SEARCH_ICON: '~search icn',
   HELP_ICON: '~help icn',
   SEARCH_FIELD: '~searchAllEmailField',
-  INBOX_LIST: '-ios class chain:**/XCUIElementTypeOther/XCUIElementTypeTable[2]/XCUIElementTypeCell',
+  INBOX_LIST: '~aid-inbox-list',
 };
 
 class MailFolderScreen extends BaseScreen {
@@ -47,7 +47,7 @@ class MailFolderScreen extends BaseScreen {
   }
 
   get inboxList() {
-      return $$(SELECTORS.INBOX_LIST);
+    return $$(SELECTORS.INBOX_LIST);
   }
 
   checkTrashScreen = async () => {

--- a/appium/tests/screenobjects/mail-folder.screen.ts
+++ b/appium/tests/screenobjects/mail-folder.screen.ts
@@ -9,7 +9,8 @@ const SELECTORS = {
   INBOX_HEADER: '~navigationItemInbox',
   SEARCH_ICON: '~search icn',
   HELP_ICON: '~help icn',
-  SEARCH_FIELD: '~searchAllEmailField'
+  SEARCH_FIELD: '~searchAllEmailField',
+  INBOX_LIST: '-ios class chain:**/XCUIElementTypeOther/XCUIElementTypeTable[2]/XCUIElementTypeCell',
 };
 
 class MailFolderScreen extends BaseScreen {
@@ -43,6 +44,10 @@ class MailFolderScreen extends BaseScreen {
 
   get searchField() {
     return $(SELECTORS.SEARCH_FIELD);
+  }
+
+  get inboxList() {
+      return $$(SELECTORS.INBOX_LIST);
   }
 
   checkTrashScreen = async () => {
@@ -86,6 +91,21 @@ class MailFolderScreen extends BaseScreen {
   clickOnUserEmail = async (email: string) => {
     await (await this.createEmailButton).waitForDisplayed();
     await $(`~${email}`).click();
+  }
+
+  scrollDownToEmail = async (subject: string) => {
+    const elem = $(`~${subject}`);
+    await TouchHelper.scrollDownToElement(await elem);
+  };
+
+  getEmailCount = async () => {
+      await browser.pause(1000);
+      return await this.inboxList.length;
+  };
+
+  scrollUpToFirstEmail = async () => {
+    const elem = await this.inboxList[0];
+    await TouchHelper.scrollUpToElement(elem);
   }
 
   checkInboxScreen = async () => {

--- a/appium/tests/specs/live/inbox/CheckinboxPaginationAfterLoadingAllEmails.spec.ts
+++ b/appium/tests/specs/live/inbox/CheckinboxPaginationAfterLoadingAllEmails.spec.ts
@@ -1,0 +1,27 @@
+import {
+  SplashScreen,
+  SetupKeyScreen,
+  MailFolderScreen,
+} from '../../../screenobjects/all-screens';
+
+import { CommonData } from '../../../data';
+import MailFolderHelper from "../../../helpers/MailFolderHelper";
+
+describe('INBOX: ', () => {
+
+  it('check inbox pagination after loading all messages', async () => {
+
+    const firstEmailSubject = CommonData.simpleEmail.subject;
+
+    await SplashScreen.login();
+    await SetupKeyScreen.setPassPhrase();
+    await MailFolderScreen.checkInboxScreen();
+
+    await MailFolderHelper.checkPagination(firstEmailSubject);
+
+    await MailFolderScreen.scrollUpToFirstEmail();
+    await MailFolderScreen.refreshMailList();
+
+    await MailFolderHelper.checkPagination(firstEmailSubject);
+  });
+});


### PR DESCRIPTION
This PR contains tests for checking inbox pagination after loading all messages

covered this case:

1. open Inbox screen
2. check number of messages (should be 20)
3. scroll to the bottom to load next page
4. check number of messages (should be more than 20)
5. scroll to the top of the list and perform pull-to-refresh
6. check number of messages (should be 20)
7. scroll to the bottom to load next page
8. check number of messages (should be more than 20)

close #1288 

issue #1366 


----------------------------------

**Tests** 
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
