### PR TITLE
#1366 Infinite call to fetchAndRenderEmailsOnly issue for empty folders

### DIFF
--- a/FlowCrypt/Controllers/Inbox/InboxViewController.swift
+++ b/FlowCrypt/Controllers/Inbox/InboxViewController.swift
@@ -276,12 +276,8 @@ extension InboxViewController {
     }
 
     private func handleNew(_ input: InboxContext) {
-        if input.data.isEmpty {
-            state = .empty
-        } else {
-            inboxInput = input.data
-            state = .fetched(input.pagination)
-        }
+        inboxInput = input.data
+        state = .fetched(input.pagination)
         refreshControl.endRefreshing()
         tableNode.reloadData()
     }

--- a/FlowCrypt/Controllers/Inbox/InboxViewController.swift
+++ b/FlowCrypt/Controllers/Inbox/InboxViewController.swift
@@ -177,6 +177,7 @@ extension InboxViewController {
     private func fetchAndRenderEmailsOnly(_ batchContext: ASBatchContext?) {
         Task {
             do {
+                state = .fetching
                 let context = try await service.fetchInboxItems(
                     using: FetchMessageContext(
                         folderPath: viewModel.path,
@@ -184,6 +185,7 @@ extension InboxViewController {
                         pagination: currentMessagesListPagination()
                     ), userEmail: appContext.user.email
                 )
+                state = .refresh
                 handleEndFetching(with: context, context: batchContext)
             } catch {
                 handle(error: error)


### PR DESCRIPTION
This PR fixes infinite call to fetchAndRenderEmailsOnly issue for empty folders & inbox loads 2 pages issue.

close #1366 // if this PR closes an issue

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
