### PR TITLE
#853 Use local contact if public key lookup failed

### DIFF
--- a/FlowCrypt/Controllers/Compose/ComposeViewController.swift
+++ b/FlowCrypt/Controllers/Compose/ComposeViewController.swift
@@ -1049,15 +1049,17 @@ extension ComposeViewController {
         }
 
         Task {
+            var localContact: RecipientWithSortedPubKeys?
             do {
                 if let contact = try await service.findLocalContact(with: recipient.email) {
+                    localContact = contact
                     handleEvaluation(for: contact)
                 }
 
                 let contactWithFetchedKeys = try await service.fetchContact(with: recipient.email)
                 handleEvaluation(for: contactWithFetchedKeys)
             } catch {
-                handleEvaluation(error: error, with: recipient.email)
+                handleEvaluation(error: error, with: recipient.email, localContact: localContact)
             }
         }
     }
@@ -1085,8 +1087,11 @@ extension ComposeViewController {
         }
     }
 
-    private func handleEvaluation(error: Error, with email: String) {
+    private func handleEvaluation(error: Error, with email: String, localContact: RecipientWithSortedPubKeys?) {
         let recipientState: RecipientState = {
+            if let _localContact = localContact {
+                return getRecipientState(from: _localContact)
+            }
             switch error {
             case ContactsError.keyMissing:
                 return self.decorator.recipientKeyNotFoundState

--- a/FlowCrypt/Controllers/Compose/ComposeViewController.swift
+++ b/FlowCrypt/Controllers/Compose/ComposeViewController.swift
@@ -1059,7 +1059,7 @@ extension ComposeViewController {
                 let contactWithFetchedKeys = try await service.fetchContact(with: recipient.email)
                 handleEvaluation(for: contactWithFetchedKeys)
             } catch {
-                handleEvaluation(error: error, with: recipient.email, localContact: localContact)
+                handleEvaluation(error: error, with: recipient.email, contact: localContact)
             }
         }
     }
@@ -1087,10 +1087,10 @@ extension ComposeViewController {
         }
     }
 
-    private func handleEvaluation(error: Error, with email: String, localContact: RecipientWithSortedPubKeys?) {
+    private func handleEvaluation(error: Error, with email: String, contact: RecipientWithSortedPubKeys?) {
         let recipientState: RecipientState = {
-            if let _localContact = localContact {
-                return getRecipientState(from: _localContact)
+            if let contact = contact, contact.keyState == .active {
+                return getRecipientState(from: contact)
             }
             switch error {
             case ContactsError.keyMissing:


### PR DESCRIPTION
This PR uses local contact to display compose view recipient state if public key lookup failed.

close #853 // if this PR closes an issue

----------------------------------

**Tests** _(delete all except exactly one)_:
- Difficult to test (This issue needs offline status or server down status to be reproduced)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
