### PR TITLE
fix codeowners format

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 * @tomholub
 Core/* @tomholub
 FlowCrypt/Core/* @tomholub
-FlowCrypt/Functionality/Services/Organisational Rules Service/* @tomholub
-FlowCrypt/Functionality/Services/Client Configuration Service/* @tomholub
+FlowCrypt/Functionality/Services/Organisational\ Rules\ Service/* @tomholub
+FlowCrypt/Functionality/Services/Client\ Configuration\ Service/* @tomholub


### PR DESCRIPTION
This PR fixes paths in github codeowners file. Spaces were earlier understood as separating users, but they were actually spaces in the file path.

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
