### PR TITLE
#1442 Added retry logic for get threads list and thread info

### DIFF
--- a/FlowCrypt.xcodeproj/project.pbxproj
+++ b/FlowCrypt.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		040FDF1227EDFC5C00CB936A /* IdTokenUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 040FDF1127EDFC5C00CB936A /* IdTokenUtils.swift */; };
 		04127DFD27E3097E009DF86C /* LocalContactsProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04127DFC27E3097E009DF86C /* LocalContactsProviderMock.swift */; };
 		0435F35927E499CA008AEEF6 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0435F35827E499CA008AEEF6 /* SearchViewController.swift */; };
+		0443C85E27F4A6D700A432AA /* Task+Retry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0443C85D27F4A6D700A432AA /* Task+Retry.swift */; };
 		04A1724A27F2FD2F00B79559 /* GoogleUserService+Contacts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04A1724927F2FD2F00B79559 /* GoogleUserService+Contacts.swift */; };
 		04B4728D1ECE29D200B8266F /* KeypairRealmObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04B4728B1ECE29D200B8266F /* KeypairRealmObject.swift */; };
 		04B472951ECE29F600B8266F /* MyMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04B472921ECE29F600B8266F /* MyMenuViewController.swift */; };
@@ -430,6 +431,7 @@
 		040FDF1127EDFC5C00CB936A /* IdTokenUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdTokenUtils.swift; sourceTree = "<group>"; };
 		04127DFC27E3097E009DF86C /* LocalContactsProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalContactsProviderMock.swift; sourceTree = "<group>"; };
 		0435F35827E499CA008AEEF6 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
+		0443C85D27F4A6D700A432AA /* Task+Retry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Task+Retry.swift"; sourceTree = "<group>"; };
 		049C4FBB54F5709AE2F2301B /* Pods-FlowCryptUI.enterprise.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FlowCryptUI.enterprise.xcconfig"; path = "Target Support Files/Pods-FlowCryptUI/Pods-FlowCryptUI.enterprise.xcconfig"; sourceTree = "<group>"; };
 		04A1724927F2FD2F00B79559 /* GoogleUserService+Contacts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GoogleUserService+Contacts.swift"; sourceTree = "<group>"; };
 		04B4728B1ECE29D200B8266F /* KeypairRealmObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeypairRealmObject.swift; sourceTree = "<group>"; };
@@ -1509,6 +1511,7 @@
 			isa = PBXGroup;
 			children = (
 				32DCA4B11D4531B3B04D01D1 /* AppErr.swift */,
+				0443C85D27F4A6D700A432AA /* Task+Retry.swift */,
 			);
 			path = "Error Handling";
 			sourceTree = "<group>";
@@ -2728,6 +2731,7 @@
 				9F0C3C142316E69300299985 /* User.swift in Sources */,
 				2155E9EF26E3628C008FB033 /* Refreshable.swift in Sources */,
 				9F3EF32523B15C1400FA0CEF /* ImapHelper.swift in Sources */,
+				0443C85E27F4A6D700A432AA /* Task+Retry.swift in Sources */,
 				D212D36024C1AC0D00035991 /* KeyDetails.swift in Sources */,
 				9F9AAFFD2383E216000A00F1 /* Document.swift in Sources */,
 				9FE1B3A02565B0CE00D6D086 /* Message.swift in Sources */,

--- a/FlowCrypt/Functionality/Error Handling/Task+Retry.swift
+++ b/FlowCrypt/Functionality/Error Handling/Task+Retry.swift
@@ -15,7 +15,7 @@ extension Task where Failure == Error {
         operation: @Sendable @escaping () async throws -> Success
     ) -> Task {
         Task(priority: priority) {
-            for _ in 0..<maxRetryCount {
+            for _ in 0 ..< maxRetryCount {
                 do {
                     return try await operation()
                 } catch {

--- a/FlowCrypt/Functionality/Error Handling/Task+Retry.swift
+++ b/FlowCrypt/Functionality/Error Handling/Task+Retry.swift
@@ -22,8 +22,6 @@ extension Task where Failure == Error {
                     let oneMillisecond = UInt64(1_000_000)
                     let delay = oneMillisecond * retryDelayMs
                     try await Task<Never, Never>.sleep(nanoseconds: delay)
-
-                    continue
                 }
             }
 

--- a/FlowCrypt/Functionality/Error Handling/Task+Retry.swift
+++ b/FlowCrypt/Functionality/Error Handling/Task+Retry.swift
@@ -10,7 +10,7 @@ extension Task where Failure == Error {
     @discardableResult
     static func retrying(
         priority: TaskPriority? = nil,
-        maxRetryCount: Int = 3,
+        maxRetryCount: Int = 2,
         retryDelay: TimeInterval = 1,
         operation: @Sendable @escaping () async throws -> Success
     ) -> Task {

--- a/FlowCrypt/Functionality/Error Handling/Task+Retry.swift
+++ b/FlowCrypt/Functionality/Error Handling/Task+Retry.swift
@@ -11,7 +11,7 @@ extension Task where Failure == Error {
     static func retrying(
         priority: TaskPriority? = nil,
         maxRetryCount: Int = 2,
-        retryDelay: TimeInterval = 1,
+        retryDelayMs: UInt64 = 1000,
         operation: @Sendable @escaping () async throws -> Success
     ) -> Task {
         Task(priority: priority) {
@@ -19,8 +19,8 @@ extension Task where Failure == Error {
                 do {
                     return try await operation()
                 } catch {
-                    let oneSecond = TimeInterval(1_000_000_000)
-                    let delay = UInt64(oneSecond * retryDelay)
+                    let oneMillisecond = UInt64(1_000_000)
+                    let delay = oneMillisecond * retryDelayMs
                     try await Task<Never, Never>.sleep(nanoseconds: delay)
 
                     continue

--- a/FlowCrypt/Functionality/Error Handling/Task+Retry.swift
+++ b/FlowCrypt/Functionality/Error Handling/Task+Retry.swift
@@ -1,0 +1,34 @@
+//
+//  Task+Retry.swift
+//  FlowCrypt
+//
+//  Created by Ioan Moldovan on 3/30/22
+//  Copyright © 2017-present FlowCrypt a. s. All rights reserved.
+//
+
+extension Task where Failure == Error {
+    @discardableResult
+    static func retrying(
+        priority: TaskPriority? = nil,
+        maxRetryCount: Int = 3,
+        retryDelay: TimeInterval = 1,
+        operation: @Sendable @escaping () async throws -> Success
+    ) -> Task {
+        Task(priority: priority) {
+            for _ in 0..<maxRetryCount {
+                do {
+                    return try await operation()
+                } catch {
+                    let oneSecond = TimeInterval(1_000_000_000)
+                    let delay = UInt64(oneSecond * retryDelay)
+                    try await Task<Never, Never>.sleep(nanoseconds: delay)
+
+                    continue
+                }
+            }
+
+            try Task<Never, Never>.checkCancellation()
+            return try await operation()
+        }
+    }
+}

--- a/FlowCrypt/Functionality/Mail Provider/Threads/MessagesThreadProvider.swift
+++ b/FlowCrypt/Functionality/Mail Provider/Threads/MessagesThreadProvider.swift
@@ -46,54 +46,58 @@ extension GmailService: MessagesThreadProvider {
 
     private func getThreadsList(using context: FetchMessageContext) async throws -> GTLRGmail_ListThreadsResponse {
         let query = makeQuery(using: context)
-        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<GTLRGmail_ListThreadsResponse, Error>) in
-            self.gmailService.executeQuery(query) { _, data, error in
-                if let error = error {
-                    return continuation.resume(throwing: GmailServiceError.providerError(error))
-                }
+        return try await Task.retrying {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<GTLRGmail_ListThreadsResponse, Error>) in
+                self.gmailService.executeQuery(query) { _, data, error in
+                    if let error = error {
+                        return continuation.resume(throwing: GmailServiceError.providerError(error))
+                    }
 
-                guard let threadsResponse = data as? GTLRGmail_ListThreadsResponse else {
-                    return continuation.resume(throwing: AppErr.cast("GTLRGmail_ListThreadsResponse"))
+                    guard let threadsResponse = data as? GTLRGmail_ListThreadsResponse else {
+                        return continuation.resume(throwing: AppErr.cast("GTLRGmail_ListThreadsResponse"))
+                    }
+                    return continuation.resume(returning: threadsResponse)
                 }
-                return continuation.resume(returning: threadsResponse)
             }
-        }
+        }.value
     }
 
     private func getThread(with identifier: String, snippet: String?, path: String) async throws -> MessageThread {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<MessageThread, Error>) in
-            self.gmailService.executeQuery(
-                GTLRGmailQuery_UsersThreadsGet.query(withUserId: .me, identifier: identifier)
-            ) { (_, data, error) in
-                if let error = error {
-                    return continuation.resume(throwing: GmailServiceError.providerError(error))
-                }
+        return try await Task.retrying {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<MessageThread, Error>) in
+                self.gmailService.executeQuery(
+                    GTLRGmailQuery_UsersThreadsGet.query(withUserId: .me, identifier: identifier)
+                ) { (_, data, error) in
+                    if let error = error {
+                        return continuation.resume(throwing: GmailServiceError.providerError(error))
+                    }
 
-                guard let thread = data as? GTLRGmail_Thread else {
-                    return continuation.resume(throwing: AppErr.cast("GTLRGmail_Thread"))
-                }
+                    guard let thread = data as? GTLRGmail_Thread else {
+                        return continuation.resume(throwing: AppErr.cast("GTLRGmail_Thread"))
+                    }
 
-                guard let threadMsg = thread.messages else {
-                    let empty = MessageThread(
-                        identifier: identifier,
+                    guard let threadMsg = thread.messages else {
+                        let empty = MessageThread(
+                            identifier: identifier,
+                            snippet: snippet,
+                            path: path,
+                            messages: []
+                        )
+                        return continuation.resume(returning: empty)
+                    }
+
+                    let messages = threadMsg.compactMap { try? Message($0, draftIdentifier: nil) }
+
+                    let result = MessageThread(
+                        identifier: thread.identifier,
                         snippet: snippet,
                         path: path,
-                        messages: []
+                        messages: messages
                     )
-                    return continuation.resume(returning: empty)
+                    return continuation.resume(returning: result)
                 }
-
-                let messages = threadMsg.compactMap { try? Message($0, draftIdentifier: nil) }
-
-                let result = MessageThread(
-                    identifier: thread.identifier,
-                    snippet: snippet,
-                    path: path,
-                    messages: messages
-                )
-                return continuation.resume(returning: result)
             }
-        }
+        }.value
     }
 
     private func makeQuery(using context: FetchMessageContext) -> GTLRGmailQuery_UsersThreadsList {

--- a/FlowCryptAppTests/Functionality/Mail Provider/GmailServiceTest.swift
+++ b/FlowCryptAppTests/Functionality/Mail Provider/GmailServiceTest.swift
@@ -48,7 +48,7 @@ class GoogleUserServiceMock: GoogleUserServiceType {
     func renewSession() async throws {
         try await Task.sleep(nanoseconds: 1_000_000_000)
     }
-    
+
     var isContactsScopeEnabled = true
     func searchContacts(query: String) async throws -> [Recipient] {
         return []


### PR DESCRIPTION
This PR added retry logic for Task level and added this logic in get threads list and get thread info calls.
Default retry count is `3` and can be changed by passing `maxRetryCount` parameter.

close #1442 // if this PR closes an issue

----------------------------------

**Tests** _(delete all except exactly one)_:
- Difficult to test (not sure what & how to test)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
