### PR TITLE
#1513 enable EKM setup without FORBID_STORING_PASS_PHRASE

### DIFF
--- a/FlowCrypt/Controllers/Setup/SetupEKMKeyViewController.swift
+++ b/FlowCrypt/Controllers/Setup/SetupEKMKeyViewController.swift
@@ -72,7 +72,7 @@ extension SetupEKMKeyViewController {
     private func setupAccountWithKeysFetchedFromEkm(with passPhrase: String) async throws {
         self.showSpinner()
         let clientConfiguration = try await appContext.clientConfigurationService.configuration
-        storageMethod = clientConfiguration.forbidStoringPassPhrase ? .memory : .persistent
+        self.storageMethod = clientConfiguration.forbidStoringPassPhrase ? .memory : .persistent
         try await self.validateAndConfirmNewPassPhraseOrReject(passPhrase: passPhrase)
         var allFingerprintsOfAllKeys: [[String]] = []
         for keyDetail in self.keys {
@@ -93,7 +93,7 @@ extension SetupEKMKeyViewController {
             allFingerprintsOfAllKeys.append(contentsOf: parsedKey.keyDetails.map(\.fingerprints))
         }
         // Save pass phrase in memory when FORBID_STORING_PASS_PHRASE is set
-        if storageMethod == .memory {
+        if self.storageMethod == .memory {
             for allFingerprintsOfOneKey in allFingerprintsOfAllKeys {
                 try appContext.passPhraseService.savePassPhrase(
                     with: PassPhrase(

--- a/FlowCrypt/Functionality/Services/Client Configuration Service/ClientConfiguration.swift
+++ b/FlowCrypt/Functionality/Services/Client Configuration Service/ClientConfiguration.swift
@@ -178,9 +178,6 @@ class ClientConfiguration {
         guard !mustAutogenPassPhraseQuietly else {
             return .inconsistentClientConfiguration(checkError: .autogenPassPhraseQuietly)
         }
-        guard forbidStoringPassPhrase else {
-            return .inconsistentClientConfiguration(checkError: .forbidStoringPassPhrase)
-        }
         guard !mustSubmitAttester else {
             return .inconsistentClientConfiguration(checkError: .mustSubmitAttester)
         }
@@ -197,7 +194,6 @@ class ClientConfiguration {
         case urlNotValid
         case autoImportOrAutogenPrvWithKeyManager
         case autogenPassPhraseQuietly
-        case forbidStoringPassPhrase
         case mustSubmitAttester
 
         var description: String {
@@ -208,8 +204,6 @@ class ClientConfiguration {
                 return "organisational_rules_autoimport_or_autogen_with_private_key_manager_error".localized
             case .autogenPassPhraseQuietly:
                 return "organisational_rules_autogen_passphrase_quitely_error".localized
-            case .forbidStoringPassPhrase:
-                return "organisational_rules_forbid_storing_passphrase_error".localized
             case .mustSubmitAttester:
                 return "organisational_rules_must_submit_attester_error".localized
             }

--- a/FlowCryptAppTests/Functionality/Services/Client Configuration Service/ClientConfigurationTests.swift
+++ b/FlowCryptAppTests/Functionality/Services/Client Configuration Service/ClientConfigurationTests.swift
@@ -182,20 +182,6 @@ class ClientConfigurationTests: XCTestCase {
         XCTAssert(error == .autogenPassPhraseQuietly)
     }
 
-    func testCheckShouldUseEKMFailForForbidStoringPassPhrase() {
-        let result = ClientConfiguration(raw: RawClientConfiguration(
-            flags: [
-                .privateKeyAutoimportOrAutogen
-            ],
-            keyManagerUrl: "https://ekm.example.com"
-        )).checkUsesEKM()
-        guard case .inconsistentClientConfiguration(let error) = result else {
-            return XCTFail()
-        }
-
-        XCTAssert(error == .forbidStoringPassPhrase)
-    }
-
     func testCheckShouldUseEKMFailForMustSubmitAttester() {
         let result = ClientConfiguration(raw: RawClientConfiguration(
             flags: [


### PR DESCRIPTION
This PR saves pass phrase in memory when FORBID_STORING_PASS_PHRASE is set in EKM Setup

close #1513 // if this PR closes an issue

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed (will be tested in https://github.com/FlowCrypt/flowcrypt-ios/pull/1510 )
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
