### PR TITLE
#593 Use ifNotNil

### DIFF
--- a/FlowCrypt.xcodeproj/project.pbxproj
+++ b/FlowCrypt.xcodeproj/project.pbxproj
@@ -145,6 +145,7 @@
 		5ADEDCC023A43B0800EC495E /* KeyDetailInfoViewDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ADEDCBF23A43B0800EC495E /* KeyDetailInfoViewDecorator.swift */; };
 		601EEE31272B19D200FE445B /* CheckMailAuthViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601EEE30272B19D200FE445B /* CheckMailAuthViewController.swift */; };
 		606FE33A2745AA2E009DA039 /* AttachmentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606FE3392745AA2E009DA039 /* AttachmentViewController.swift */; };
+		750A6C3D28244A780048E1CC /* OptionalExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 750A6C3C28244A780048E1CC /* OptionalExtensions.swift */; };
 		7F72537A0C44D3CE670F0EFD /* Pods_FlowCryptUIApplication.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3382C015A576728FA08BA310 /* Pods_FlowCryptUIApplication.framework */; };
 		949ED9422303E3B400530579 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 949ED9412303E3B400530579 /* Colors.xcassets */; };
 		9F003D6125E1B4ED00EB38C0 /* TrashFolderProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F003D6025E1B4ED00EB38C0 /* TrashFolderProvider.swift */; };
@@ -608,6 +609,7 @@
 		5ADEDCC123A43C6800EC495E /* KeyTextCellNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyTextCellNode.swift; sourceTree = "<group>"; };
 		601EEE30272B19D200FE445B /* CheckMailAuthViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckMailAuthViewController.swift; sourceTree = "<group>"; };
 		606FE3392745AA2E009DA039 /* AttachmentViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttachmentViewController.swift; sourceTree = "<group>"; };
+		750A6C3C28244A780048E1CC /* OptionalExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalExtensions.swift; sourceTree = "<group>"; };
 		949ED9412303E3B400530579 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		9F003D6025E1B4ED00EB38C0 /* TrashFolderProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrashFolderProvider.swift; sourceTree = "<group>"; };
 		9F003D6C25EA8F3200EB38C0 /* SessionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionService.swift; sourceTree = "<group>"; };
@@ -2016,6 +2018,7 @@
 				32DCA7E0AFE19FACB0F233ED /* URLSessionExtensions.swift */,
 				9FD22A1B230FE7D0005067A6 /* Then.swift */,
 				D2FD0F682453245E00259FF0 /* Either.swift */,
+				750A6C3C28244A780048E1CC /* OptionalExtensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -3011,6 +3014,7 @@
 				9FBD69EC27775086002FC602 /* UIApplicationExtensions.swift in Sources */,
 				D2CDC3D42402D50A002B045F /* CodableExtensions.swift in Sources */,
 				9FD505272785C2CD00FAA82F /* UIDeviceExtensions.swift in Sources */,
+				750A6C3D28244A780048E1CC /* OptionalExtensions.swift in Sources */,
 				D2531F3D24000E37007E5198 /* UIVIewExtensions.swift in Sources */,
 				D2531F3723FFF043007E5198 /* CommonExtensions.swift in Sources */,
 				D2CDC3D32402D4FE002B045F /* DataExtensions.swift in Sources */,

--- a/FlowCrypt/Functionality/Services/Contacts Service/Models/PubKey.swift
+++ b/FlowCrypt/Functionality/Services/Contacts Service/Models/PubKey.swift
@@ -59,7 +59,7 @@ extension PubKey {
             armored: keyDetails.public,
             lastSig: keyDetails.lastModified.map { Date(timeIntervalSince1970: TimeInterval($0)) },
             lastChecked: Date(),
-            expiresOn: keyDetails.expiration.map { Date(timeIntervalSince1970: TimeInterval($0)) },
+            expiresOn: keyDetails.expiration.ifNotNil { Date(timeIntervalSince1970: TimeInterval($0)) },
             longids: longids,
             fingerprints: fingerprints,
             created: Date(timeIntervalSince1970: Double(keyDetails.created)),

--- a/FlowCryptCommon/Extensions/OptionalExtensions.swift
+++ b/FlowCryptCommon/Extensions/OptionalExtensions.swift
@@ -1,0 +1,20 @@
+//
+//  OptionalExtensions.swift
+//  FlowCryptCommon
+//
+//  Created by Ioan Moldovan on 5/5/22
+//  Copyright © 2017-present FlowCrypt a. s. All rights reserved.
+//
+
+import Foundation
+
+extension Optional {
+    public func ifNotNil<U>(_ transform: (Wrapped) throws -> U) rethrows -> U? {
+        switch self {
+        case .some(let value):
+          return .some(try transform(value))
+        case .none:
+          return .none
+        }
+    }
+}


### PR DESCRIPTION
This PR uses `ifNotNil` instead of `map` for optionals to avoid confusions for non-swifters.

close #593 // if this PR closes an issue

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
