### PR TITLE
#1584 Add request URL to error modal

### DIFF
--- a/appium/tests/specs/mock/setup/SetupShowsMeaningfulErrorFromFES.spec.ts
+++ b/appium/tests/specs/mock/setup/SetupShowsMeaningfulErrorFromFES.spec.ts
@@ -18,7 +18,7 @@ describe('SETUP: ', () => {
     await mockApi.withMockedApis(async () => {
       await SplashScreen.login();
       await BaseScreen.checkModalMessage('Login Error\n' +
-          'EnterpriseServerApi 400 message:some client err get http://127.0.0.1:8001/fes/api/');
+        'EnterpriseServerApi 400 message:some client err GET http://127.0.0.1:8001/fes/api/');
     });
   });
 });


### PR DESCRIPTION
This PR adds request URL to API error modal

<img width="207" alt="Screenshot 2022-05-06 at 23 22 15" src="https://user-images.githubusercontent.com/1062093/167212003-4fc1b40d-851f-46df-934d-0e721e231cd9.png">

close #1584

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
