### PR TITLE
#1176 Update recipient.lastUsed only when composing

### DIFF
--- a/FlowCrypt/Functionality/Mail Provider/Message Provider/MessageService.swift
+++ b/FlowCrypt/Functionality/Mail Provider/Message Provider/MessageService.swift
@@ -227,7 +227,7 @@ extension MessageService {
     private func fetchVerificationPubKeys(for sender: Recipient?, onlyLocal: Bool) async throws -> [String] {
         guard let sender = sender else { return [] }
 
-        let pubKeys = try localContactsProvider.retrievePubKeys(for: sender.email)
+        let pubKeys = try localContactsProvider.retrievePubKeys(for: sender.email, shouldUpdateLastUsed: false)
         if pubKeys.isNotEmpty || onlyLocal { return pubKeys }
 
         guard let contact = try? await pubLookup.fetchRemoteUpdateLocal(with: sender)

--- a/FlowCrypt/Functionality/Services/Compose Message Service/ComposeMessageService.swift
+++ b/FlowCrypt/Functionality/Services/Compose Message Service/ComposeMessageService.swift
@@ -184,7 +184,10 @@ final class ComposeMessageService {
         let recipients = composeRecipients.map(Recipient.init)
         var recipientsWithKeys: [RecipientWithSortedPubKeys] = []
         for recipient in recipients {
-            let armoredPubkeys = try localContactsProvider.retrievePubKeys(for: recipient.email).joined(separator: "\n")
+            let armoredPubkeys = try localContactsProvider.retrievePubKeys(
+                for: recipient.email,
+                shouldUpdateLastUsed: true
+            ).joined(separator: "\n")
             let parsed = try await self.core.parseKeys(armoredOrBinary: armoredPubkeys.data())
             recipientsWithKeys.append(
                 try RecipientWithSortedPubKeys(recipient, keyDetails: parsed.keyDetails)

--- a/FlowCrypt/Functionality/Services/Local Contacts Service/LocalContactsProvider.swift
+++ b/FlowCrypt/Functionality/Services/Local Contacts Service/LocalContactsProvider.swift
@@ -16,7 +16,7 @@ enum ContactsError: Error {
 }
 
 protocol PublicKeyProvider {
-    func retrievePubKeys(for email: String) throws -> [String]
+    func retrievePubKeys(for email: String, shouldUpdateLastUsed: Bool) throws -> [String]
     func removePubKey(with fingerprint: String, for email: String) throws
 }
 
@@ -51,17 +51,18 @@ final class LocalContactsProvider {
 }
 
 extension LocalContactsProvider: LocalContactsProviderType {
-    func retrievePubKeys(for email: String) throws -> [String] {
+    func retrievePubKeys(for email: String, shouldUpdateLastUsed: Bool) throws -> [String] {
         guard let object = try find(with: email) else { return [] }
 
-        do {
-            try storage.write {
-                object.lastUsed = Date()
+        if shouldUpdateLastUsed {
+            do {
+                try storage.write {
+                    object.lastUsed = Date()
+                }
+            } catch {
+                logger.logError("fail to update last used property \(error)")
             }
-        } catch {
-            logger.logError("fail to update last used property \(error)")
         }
-
         return object.pubKeys.map(\.armored)
     }
 

--- a/FlowCryptAppTests/Mocks/LocalContactsProviderMock.swift
+++ b/FlowCryptAppTests/Mocks/LocalContactsProviderMock.swift
@@ -24,7 +24,7 @@ final class LocalContactsProviderMock: LocalContactsProviderType {
     func getAllRecipients() async throws -> [RecipientWithSortedPubKeys] { [] }
 
     var retrievePubKeysResult: ((String) -> ([String]))!
-    func retrievePubKeys(for email: String) -> [String] {
+    func retrievePubKeys(for email: String, shouldUpdateLastUsed: Bool) -> [String] {
         retrievePubKeysResult(email)
     }
 


### PR DESCRIPTION
This PR updates recipient.lastUsed only when composing

close #1176 // if this PR closes an issue

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
