### PR TITLE
#1834 attester api methods naming

### DIFF
--- a/FlowCrypt/Controllers/Setup/SetupGenerateKeyViewController.swift
+++ b/FlowCrypt/Controllers/Setup/SetupGenerateKeyViewController.swift
@@ -84,9 +84,12 @@ final class SetupGenerateKeyViewController: SetupCreatePassphraseAbstractViewCon
         }
 
         // sending welcome email is not crucial, so we don't handle errors
-        _ = try? await attester.testWelcome(
+        guard let idToken = try? await IdTokenUtils.getIdToken(user: appContext.user) else { return }
+
+        try? await attester.testWelcome(
             email: appContext.user.email,
-            pubkey: encryptedPrv.key.public
+            pubkey: encryptedPrv.key.public,
+            idToken: idToken
         )
     }
 
@@ -108,7 +111,7 @@ final class SetupGenerateKeyViewController: SetupCreatePassphraseAbstractViewCon
         publicKey: String
     ) async throws {
         do {
-            _ = try await attester.replace(
+            _ = try await attester.submitPrimaryEmailPubkey(
                 email: user.email,
                 pubkey: publicKey,
                 idToken: try await IdTokenUtils.getIdToken(user: user)

--- a/appium/api-mocks/apis/attester/attester-endpoints.ts
+++ b/appium/api-mocks/apis/attester/attester-endpoints.ts
@@ -52,7 +52,7 @@ export const getMockAttesterEndpoints = (
         throw new AttesterErr(`Not implemented: ${req.method}`, Status.BAD_REQUEST);
       }
     },
-    '/attester/test/welcome': async ({ body }, req) => {
+    '/attester/welcome-message': async ({ body }, req) => {
       throwErrorIfConfigSaysSo(attesterConfig);
 
       if (!attesterConfig.enableTestWelcome) {


### PR DESCRIPTION
This PR renames attester api methods

close #1834

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
