### PR TITLE
#1911 Allow empty messages with attachments

### DIFF
--- a/FlowCrypt/Functionality/Services/Compose Message Service/ComposeMessageService.swift
+++ b/FlowCrypt/Functionality/Services/Compose Message Service/ComposeMessageService.swift
@@ -127,7 +127,10 @@ final class ComposeMessageService {
                 throw MessageValidationError.emptySubject
             }
 
-            guard let text = contextToSend.message, text.hasContent else {
+            let hasText = contextToSend.message?.hasContent ?? false
+            let hasAttachments = !contextToSend.attachments.isEmpty
+
+            guard hasText || hasAttachments else {
                 throw MessageValidationError.emptyMessage
             }
 


### PR DESCRIPTION
This PR allows sending of empty messages with attachments

close #1911

----------------------------------

**Tests** _(delete all except exactly one)_:
- Difficult to test (explain why) - adding attachments in appium ui tests is complicated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
