### PR TITLE
#2048 Add external-service to expected service value in FES response

### DIFF
--- a/FlowCrypt/Functionality/Api/Account Server Apis/EnterpriseServerApiHelper.swift
+++ b/FlowCrypt/Functionality/Api/Account Server Apis/EnterpriseServerApiHelper.swift
@@ -74,7 +74,8 @@ struct EnterpriseServerApiHelper {
         guard let responseDictionary = try? responseData.toDict(),
               let service = responseDictionary["service"] as? String
         else { return false }
-        return service == "enterprise-server"
+        let allowedServices = ["enterprise-server", "external-service"]
+        return allowedServices.contains(service)
     }
 
     private func shouldTolerateWhenCallingOpportunistically(_ error: Error) async -> Bool {

--- a/appium/api-mocks/apis/fes/fes-endpoints.ts
+++ b/appium/api-mocks/apis/fes/fes-endpoints.ts
@@ -48,7 +48,7 @@ export const getMockFesEndpoints = (
       throwIfNotGetMethod(req);
       return {
         "vendor": "Mock",
-        "service": "enterprise-server",
+        "service": "external-service",
         "orgId": "standardsubdomainfes.test",
         "version": "MOCK",
         "apiVersion": 'v1',


### PR DESCRIPTION
This PR added `external-service` to expected service value in FES response

close #2048 // if this PR closes an issue

----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
