### PR TITLE
#418 Updated recipient selection color

### DIFF
--- a/FlowCrypt/Controllers/Compose/ComposeRecipientPopupViewController.swift
+++ b/FlowCrypt/Controllers/Compose/ComposeRecipientPopupViewController.swift
@@ -13,6 +13,7 @@ import FlowCryptUI
 protocol ComposeRecipientPopupViewControllerProtocol {
     func removeRecipient(email: String, type: RecipientType)
     func editRecipient(email: String, type: RecipientType)
+    func enableRecipientEditing()
 }
 
 /**
@@ -97,6 +98,7 @@ extension ComposeRecipientPopupViewController: ASTableDelegate, ASTableDataSourc
         default:
             break
         }
+        self.delegate?.enableRecipientEditing()
     }
 }
 

--- a/FlowCrypt/Controllers/Compose/ComposeRecipientPopupViewController.swift
+++ b/FlowCrypt/Controllers/Compose/ComposeRecipientPopupViewController.swift
@@ -14,6 +14,7 @@ protocol ComposeRecipientPopupViewControllerProtocol {
     func removeRecipient(email: String, type: RecipientType)
     func editRecipient(email: String, type: RecipientType)
     func enableRecipientEditing()
+    func deselectRecipients(type: RecipientType)
 }
 
 /**
@@ -94,6 +95,7 @@ extension ComposeRecipientPopupViewController: ASTableDelegate, ASTableDataSourc
             self.dismiss(animated: true, completion: nil)
         case .copy:
             UIPasteboard.general.string = recipient.email
+            self.delegate?.deselectRecipients(type: type)
             self.dismiss(animated: true, completion: nil)
         default:
             break

--- a/FlowCrypt/Controllers/Compose/ComposeViewDecorator.swift
+++ b/FlowCrypt/Controllers/Compose/ComposeViewDecorator.swift
@@ -13,7 +13,6 @@ typealias RecipientStateContext = RecipientEmailsCellNode.Input.StateContext
 
 struct ComposeViewDecorator {
     let recipientIdleState: RecipientState = .idle(idleStateContext)
-    let recipientSelectedState: RecipientState = .selected(selectedStateContext)
     let recipientKeyFoundState: RecipientState = .keyFound(keyFoundStateContext)
     let recipientKeyExpiredState: RecipientState = .keyExpired(keyExpiredStateContext)
     let recipientKeyRevokedState: RecipientState = .keyRevoked(keyRevokedStateContext)
@@ -250,16 +249,6 @@ extension ComposeViewDecorator {
             textColor: .mainTextColor,
             image: UIImage(named: "retry"),
             accessibilityIdentifier: "gray"
-        )
-    }
-
-    private static var selectedStateContext: RecipientStateContext {
-        RecipientStateContext(
-            backgroundColor: UIColor(hex: "E8F0FE") ?? .gray,
-            borderColor: UIColor(hex: "669EF6") ?? .borderColor,
-            textColor: UIColor(hex: "1867D2") ?? .white,
-            image: nil,
-            accessibilityIdentifier: "selected"
         )
     }
 

--- a/FlowCrypt/Controllers/Compose/ComposeViewDecorator.swift
+++ b/FlowCrypt/Controllers/Compose/ComposeViewDecorator.swift
@@ -255,11 +255,11 @@ extension ComposeViewDecorator {
 
     private static var selectedStateContext: RecipientStateContext {
         RecipientStateContext(
-            backgroundColor: .gray,
-            borderColor: .borderColor,
-            textColor: .white,
+            backgroundColor: UIColor(hex: "E8F0FE") ?? .gray,
+            borderColor: UIColor(hex: "669EF6") ?? .borderColor,
+            textColor: UIColor(hex: "1867D2") ?? .white,
             image: nil,
-            accessibilityIdentifier: "gray"
+            accessibilityIdentifier: "selected"
         )
     }
 

--- a/FlowCrypt/Controllers/Compose/Extensions/ComposeViewController+ActionHandling.swift
+++ b/FlowCrypt/Controllers/Compose/Extensions/ComposeViewController+ActionHandling.swift
@@ -136,13 +136,12 @@ extension ComposeViewController {
     }
 
     func handleRecipientSelection(with indexPath: IndexPath, type: RecipientType) {
-        guard let recipient = contextToSend.recipient(at: indexPath.row, type: type) else { return }
+        guard var recipient = contextToSend.recipient(at: indexPath.row, type: type) else { return }
 
-        let isSelected = recipient.state.isSelected
-        let state = isSelected ? decorator.recipientIdleState : decorator.recipientSelectedState
-        contextToSend.update(recipient: recipient.email, type: type, state: state)
+        recipient.state.isSelected.toggle()
+        contextToSend.update(recipient: recipient.email, type: type, state: recipient.state)
 
-        if isSelected {
+        if !recipient.state.isSelected {
             evaluate(recipient: recipient)
         }
 
@@ -161,7 +160,7 @@ extension ComposeViewController {
         switch recipient.state {
         case .idle:
             handleRecipientSelection(with: indexPath, type: type)
-        case .keyFound, .keyExpired, .keyRevoked, .keyNotFound, .invalidEmail, .selected:
+        case .keyFound, .keyExpired, .keyRevoked, .keyNotFound, .invalidEmail:
             break
         case let .error(_, isRetryError):
             if isRetryError {

--- a/FlowCrypt/Controllers/Compose/Extensions/ComposeViewController+Nodes.swift
+++ b/FlowCrypt/Controllers/Compose/Extensions/ComposeViewController+Nodes.swift
@@ -234,9 +234,20 @@ extension ComposeViewController {
             case let .imageTap(indexPath):
                 self.handleRecipientAction(with: indexPath, type: type)
             case let .select(indexPath, sender):
+                self.toggleRecipientTextField(isEnabled: false)
                 self.handleRecipientSelection(with: indexPath, type: type)
                 self.displayRecipientPopOver(with: indexPath, type: type, sender: sender)
             }
+        }
+    }
+
+    func toggleRecipientTextField(isEnabled: Bool) {
+        let types: [RecipientType] = [.to, .cc, .bcc]
+        for type in types {
+            self.recipientsTextField(type: type)?.isUserInteractionEnabled = isEnabled
+        }
+        if let type = selectedRecipientType, let textField = recipientsTextField(type: type) {
+            textField.becomeFirstResponder()
         }
     }
 

--- a/FlowCrypt/Controllers/Compose/Extensions/ComposeViewController+RecipientInput.swift
+++ b/FlowCrypt/Controllers/Compose/Extensions/ComposeViewController+RecipientInput.swift
@@ -165,7 +165,7 @@ extension ComposeViewController {
 
         if var lastRecipient = recipients.popLast() {
             // select last recipient in a list
-            lastRecipient.state = decorator.recipientSelectedState
+            lastRecipient.state.isSelected = true
             recipients.append(lastRecipient)
             contextToSend.set(recipients: recipients, for: recipientType)
 

--- a/FlowCrypt/Controllers/Compose/Extensions/ComposeViewController+RecipientInput.swift
+++ b/FlowCrypt/Controllers/Compose/Extensions/ComposeViewController+RecipientInput.swift
@@ -19,6 +19,10 @@ extension ComposeViewController {
 
         guard let text = textField.text else { nextResponder(); return true }
 
+        if !character.isEmpty {
+            deselectRecipients(type: recipientType)
+        }
+
         if text.isEmpty, character.count > 1 {
             // Pasted string
             let characterSet = CharacterSet(charactersIn: Constants.endTypingCharacters.joined())

--- a/FlowCrypt/Controllers/Compose/Extensions/ComposeViewController+RecipientPopup.swift
+++ b/FlowCrypt/Controllers/Compose/Extensions/ComposeViewController+RecipientPopup.swift
@@ -75,4 +75,8 @@ extension ComposeViewController: ComposeRecipientPopupViewControllerProtocol {
             }
         }
     }
+
+    func enableRecipientEditing() {
+        toggleRecipientTextField(isEnabled: true)
+    }
 }

--- a/FlowCrypt/Controllers/Compose/Extensions/ComposeViewController+RecipientPopup.swift
+++ b/FlowCrypt/Controllers/Compose/Extensions/ComposeViewController+RecipientPopup.swift
@@ -43,12 +43,15 @@ extension ComposeViewController: UIPopoverPresentationControllerDelegate {
     public func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
         guard let popoverVC = presentationController.presentedViewController as? ComposeRecipientPopupViewController
         else { return }
+        toggleRecipientTextField(isEnabled: true)
         let recipients = contextToSend.recipients(type: popoverVC.type)
         let selectedRecipients = recipients.filter(\.state.isSelected)
         // Deselect previous selected receipients
         for recipient in selectedRecipients {
-            contextToSend.update(recipient: recipient.email, type: popoverVC.type, state: decorator.recipientIdleState)
-            evaluate(recipient: recipient)
+            var state = recipient.state
+            state.isSelected.toggle()
+            contextToSend.update(recipient: recipient.email, type: popoverVC.type, state: state)
+            refreshRecipient(for: recipient.email, type: popoverVC.type, refreshType: .reload)
         }
     }
 }

--- a/FlowCrypt/Controllers/Compose/Extensions/ComposeViewController+RecipientPopup.swift
+++ b/FlowCrypt/Controllers/Compose/Extensions/ComposeViewController+RecipientPopup.swift
@@ -44,15 +44,7 @@ extension ComposeViewController: UIPopoverPresentationControllerDelegate {
         guard let popoverVC = presentationController.presentedViewController as? ComposeRecipientPopupViewController
         else { return }
         toggleRecipientTextField(isEnabled: true)
-        let recipients = contextToSend.recipients(type: popoverVC.type)
-        let selectedRecipients = recipients.filter(\.state.isSelected)
-        // Deselect previous selected receipients
-        for recipient in selectedRecipients {
-            var state = recipient.state
-            state.isSelected.toggle()
-            contextToSend.update(recipient: recipient.email, type: popoverVC.type, state: state)
-            refreshRecipient(for: recipient.email, type: popoverVC.type, refreshType: .reload)
-        }
+        deselectRecipients(type: popoverVC.type)
     }
 }
 
@@ -78,5 +70,17 @@ extension ComposeViewController: ComposeRecipientPopupViewControllerProtocol {
 
     func enableRecipientEditing() {
         toggleRecipientTextField(isEnabled: true)
+    }
+
+    func deselectRecipients(type: RecipientType) {
+        let recipients = contextToSend.recipients(type: type)
+        let selectedRecipients = recipients.filter(\.state.isSelected)
+        // Deselect previous selected receipients
+        for recipient in selectedRecipients {
+            var state = recipient.state
+            state.isSelected.toggle()
+            contextToSend.update(recipient: recipient.email, type: type, state: state)
+            refreshRecipient(for: recipient.email, type: type, refreshType: .reload)
+        }
     }
 }

--- a/FlowCrypt/Extensions/UIColorExtensions.swift
+++ b/FlowCrypt/Extensions/UIColorExtensions.swift
@@ -28,6 +28,15 @@ public extension UIColor {
         )
     }
 
+    func scaleAlpha(by factor: CGFloat) -> UIColor {
+        guard let components = cgColor.components, let alpha = components.last else {
+            return withAlphaComponent(factor)
+        }
+
+        let newAlpha = alpha * factor
+        return withAlphaComponent(newAlpha)
+    }
+
     static var main: UIColor {
         UIColor(r: 36, g: 156, b: 6, alpha: 1)
     }

--- a/FlowCryptUI/Cell Nodes/RecipientEmailNode.swift
+++ b/FlowCryptUI/Cell Nodes/RecipientEmailNode.swift
@@ -56,7 +56,7 @@ final class RecipientEmailNode: CellNode {
             switch input.recipient.state {
             case .idle: self.animateImageRotation()
             case .error: self.animateImageScaling()
-            case .keyFound, .keyExpired, .keyRevoked, .keyNotFound, .invalidEmail, .selected:
+            case .keyFound, .keyExpired, .keyRevoked, .keyNotFound, .invalidEmail:
                 break
             }
         }

--- a/FlowCryptUI/Cell Nodes/RecipientEmailsCellNodeInput.swift
+++ b/FlowCryptUI/Cell Nodes/RecipientEmailsCellNodeInput.swift
@@ -56,6 +56,9 @@ public extension RecipientEmailsCellNode {
             }
 
             var alpha: CGFloat {
+                if case .keyNotFound = self { // Increase opacity for keyNotFound state when selected
+                    return stateContext.isSelected ? 2.0 : 1.0
+                }
                 return stateContext.isSelected ? 0.5 : 1.0
             }
 

--- a/FlowCryptUI/Cell Nodes/RecipientEmailsCellNodeInput.swift
+++ b/FlowCryptUI/Cell Nodes/RecipientEmailsCellNodeInput.swift
@@ -15,6 +15,7 @@ public extension RecipientEmailsCellNode {
             let backgroundColor, borderColor, textColor: UIColor
             let image: UIImage?
             let accessibilityIdentifier: String?
+            var isSelected: Bool
 
             public init(
                 backgroundColor: UIColor,
@@ -28,12 +29,12 @@ public extension RecipientEmailsCellNode {
                 self.textColor = textColor
                 self.image = image
                 self.accessibilityIdentifier = accessibilityIdentifier
+                self.isSelected = false
             }
         }
 
         public enum State: CustomStringConvertible, Equatable {
             case idle(StateContext)
-            case selected(StateContext)
             case keyFound(StateContext)
             case keyExpired(StateContext)
             case keyRevoked(StateContext)
@@ -44,7 +45,6 @@ public extension RecipientEmailsCellNode {
             private var stateContext: StateContext {
                 switch self {
                 case let .idle(context),
-                     let .selected(context),
                      let .keyFound(context),
                      let .keyExpired(context),
                      let .keyRevoked(context),
@@ -55,12 +55,16 @@ public extension RecipientEmailsCellNode {
                 }
             }
 
+            var alpha: CGFloat {
+                return stateContext.isSelected ? 0.5 : 1.0
+            }
+
             var backgroundColor: UIColor {
-                stateContext.backgroundColor
+                stateContext.backgroundColor.scaleAlpha(by: alpha)
             }
 
             var borderColor: UIColor {
-                stateContext.borderColor
+                stateContext.borderColor.scaleAlpha(by: alpha)
             }
 
             public var textColor: UIColor {
@@ -76,16 +80,39 @@ public extension RecipientEmailsCellNode {
             }
 
             public var isSelected: Bool {
-                switch self {
-                case .selected: return true
-                default: return false
+                get {
+                    stateContext.isSelected
+                }
+                set {
+                    switch self {
+                    case var .idle(context):
+                        context.isSelected = newValue
+                        self = .idle(context)
+                    case var .keyFound(context):
+                        context.isSelected = newValue
+                        self = .keyFound(context)
+                    case var .keyExpired(context):
+                        context.isSelected = newValue
+                        self = .keyExpired(context)
+                    case var .keyRevoked(context):
+                        context.isSelected = newValue
+                        self = .keyRevoked(context)
+                    case var .keyNotFound(context):
+                        context.isSelected = newValue
+                        self = .keyNotFound(context)
+                    case var .invalidEmail(context):
+                        context.isSelected = newValue
+                        self = .invalidEmail(context)
+                    case var .error(context, flag):
+                        context.isSelected = newValue
+                        self = .error(context, flag)
+                    }
                 }
             }
 
             public var description: String {
                 switch self {
                 case .idle: return "idle"
-                case .selected: return "selected"
                 case .keyFound: return "keyFound"
                 case .keyExpired: return "keyExpired"
                 case .keyRevoked: return "keyRevoked"

--- a/FlowCryptUI/Nodes/TextFieldNode.swift
+++ b/FlowCryptUI/Nodes/TextFieldNode.swift
@@ -73,6 +73,14 @@ public final class TextFieldNode: ASDisplayNode {
         }
     }
 
+    override public var isUserInteractionEnabled: Bool {
+        didSet {
+            DispatchQueue.main.async {
+                self.textField.isUserInteractionEnabled = self.isUserInteractionEnabled
+            }
+        }
+    }
+
     public var textInsets: CGFloat = -7 {
         didSet {
             DispatchQueue.main.async {

--- a/appium/tests/screenobjects/new-message.screen.ts
+++ b/appium/tests/screenobjects/new-message.screen.ts
@@ -320,11 +320,6 @@ class NewMessageScreen extends BaseScreen {
     await ElementHelper.waitElementInvisible(addedRecipientEl);
   };
 
-  deleteAddedRecipientWithBackspace = async (order: number, type = 'to') => {
-    await this.showRecipientPopup(order, type);
-    await driver.sendKeys(['\b']); // backspace
-  };
-
   deleteAddedRecipientWithDoubleBackspace = async () => {
     await this.showRecipientInputIfNeeded();
     await driver.sendKeys(['\b']); // backspace

--- a/appium/tests/specs/mock/composeEmail/CheckRecipientPopup.spec.ts
+++ b/appium/tests/specs/mock/composeEmail/CheckRecipientPopup.spec.ts
@@ -45,7 +45,7 @@ describe('COMPOSE EMAIL: ', () => {
       await NewMessageScreen.checkEditRecipient(0, 'to', recipient1.name, 3);
 
       await NewMessageScreen.deleteAddedRecipient(2);
-      await NewMessageScreen.deleteAddedRecipientWithBackspace(1);
+      await NewMessageScreen.deleteAddedRecipient(1);
       await NewMessageScreen.deleteAddedRecipient(0);
     });
   });


### PR DESCRIPTION
This PR updated recipient selection color

close #418 // if this PR closes an issue
close #2304 // if this PR closes an issue

![image](https://github.com/FlowCrypt/flowcrypt-ios/assets/77344191/b267fcc4-ae63-4e4d-afd0-6c5be51b3829)
![image](https://github.com/FlowCrypt/flowcrypt-ios/assets/77344191/d4c8e3ad-9ab8-4db8-972c-4cf662cdfaa0)


----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
