### PR TITLE
#2306 Passphrase popup dark mode support

### DIFF
--- a/FlowCrypt/Resources/en.lproj/Localizable.strings
+++ b/FlowCrypt/Resources/en.lproj/Localizable.strings
@@ -9,6 +9,7 @@
 "unknown_title" = "(unknown)";
 "retry_title" = "Retry";
 "ok" = "Ok";
+"submit" = "Submit";
 "cancel" = "Cancel";
 "delete" = "Delete";
 "download" = "Download";

--- a/FlowCryptUI/Nodes/PassPhraseAlertNode.swift
+++ b/FlowCryptUI/Nodes/PassPhraseAlertNode.swift
@@ -13,20 +13,20 @@ public class PassPhraseAlertNode: ASDisplayNode {
     enum Constants {
         static let antiBruteForceProtectionAttemptsMaxValue = 5
         static let blockingTimeInSeconds: Double = 5 * 60
-        static let textColor = UIColor.colorFor(darkStyle: .white, lightStyle: .black)
-        static let okayButtonColor = UIColor(hex: "4591FC") ?? .blue
-        static let buttonFont = UIFont.boldSystemFont(ofSize: 16)
+        static let buttonFont = UIFont.systemFont(ofSize: 16)
+        static let submitButtonText = "submit".localized
+        static let cancelButtonText = "cancel".localized
     }
 
-    private lazy var overlayNode = createOverlayNode()
-    private lazy var contentView = createContentView()
-    private lazy var separatorNode = createSeparatorNode()
-    private lazy var titleLabel = createTextNode(text: title, isBold: true, fontSize: 17, identifier: "aid-enter-passphrase-title-label")
-    private lazy var messageLabel = createTextNode(text: message ?? "", isBold: false, fontSize: 13)
-    private lazy var introductionLabel = createTextNode(text: "", isBold: false, fontSize: 13, identifier: "aid-anti-brute-force-introduce-label")
-    private lazy var passPhraseTextField = createPassPhraseTextField()
-    private lazy var cancelButton = createButtonNode(title: "Cancel", color: .red, identifier: "aid-cancel-button", action: #selector(cancelButtonTapped))
-    private lazy var okayButton = createButtonNode(title: "Ok", color: Constants.okayButtonColor, identifier: "aid-ok-button", action: #selector(okayButtonTapped))
+    private var overlayNode: ASDisplayNode!
+    private var contentView: ASDisplayNode!
+    private var separatorNode: ASDisplayNode!
+    private var titleLabel: ASTextNode!
+    private var messageLabel: ASTextNode!
+    private var introductionLabel: ASTextNode!
+    private var passPhraseTextField: TextFieldNode!
+    private var cancelButton: ASButtonNode!
+    private var okayButton: ASButtonNode!
     private weak var alertTimer: Timer?
 
     private var introduction: String? { didSet { updateIntroduction() } }
@@ -63,7 +63,30 @@ public class PassPhraseAlertNode: ASDisplayNode {
         alertTimer = nil
     }
 
+    private func createNodes() {
+        overlayNode = createOverlayNode()
+        contentView = createContentView()
+        separatorNode = createSeparatorNode()
+        titleLabel = createTextNode(text: title, isBold: true, fontSize: 17, identifier: "aid-enter-passphrase-title-label")
+        messageLabel = createTextNode(text: message ?? "", isBold: false, fontSize: 13)
+        introductionLabel = createTextNode(text: "", isBold: false, fontSize: 13, identifier: "aid-anti-brute-force-introduce-label")
+        passPhraseTextField = createPassPhraseTextField()
+        cancelButton = createButtonNode(
+            title: Constants.cancelButtonText,
+            color: .systemRed,
+            identifier: "aid-cancel-button",
+            action: #selector(cancelButtonTapped)
+        )
+        okayButton = createButtonNode(
+            title: Constants.submitButtonText,
+            color: .systemBlue,
+            identifier: "aid-ok-button",
+            action: #selector(okayButtonTapped)
+        )
+    }
+
     private func setupNodes() {
+        createNodes()
         contentView.addSubnode(titleLabel)
         if message != nil {
             contentView.addSubnode(messageLabel)
@@ -133,7 +156,7 @@ public class PassPhraseAlertNode: ASDisplayNode {
         if failedPassPhraseAttempts == 0 {
             introduction = nil
         }
-        okayButton.setTitle("Ok", with: Constants.buttonFont, with: Constants.okayButtonColor, for: .normal)
+        okayButton.setTitle(Constants.submitButtonText, with: Constants.buttonFont, with: .systemBlue, for: .normal)
         okayButton.isEnabled = true
     }
 
@@ -178,7 +201,7 @@ public class PassPhraseAlertNode: ASDisplayNode {
 
     private func createSeparatorNode() -> ASDisplayNode {
         let node = ASDisplayNode()
-        node.backgroundColor = UIColor.lightGray
+        node.backgroundColor = UIColor.separator
         node.style.height = ASDimension(unit: .points, value: 0.5)
         return node
     }
@@ -190,7 +213,7 @@ public class PassPhraseAlertNode: ASDisplayNode {
             string: text,
             attributes: [
                 .font: font,
-                .foregroundColor: Constants.textColor
+                .foregroundColor: UIColor.mainTextColor
             ]
         )
 
@@ -211,7 +234,7 @@ public class PassPhraseAlertNode: ASDisplayNode {
 
     private func updateIntroduction() {
         if let introduction, !introduction.isEmpty {
-            introductionLabel.attributedText = NSAttributedString(string: introduction, attributes: [.foregroundColor: Constants.textColor])
+            introductionLabel.attributedText = NSAttributedString(string: introduction, attributes: [.foregroundColor: UIColor.mainTextColor])
             introductionLabel.isHidden = false
         } else {
             introductionLabel.isHidden = true

--- a/FlowCryptUI/Nodes/PassPhraseAlertNode.swift
+++ b/FlowCryptUI/Nodes/PassPhraseAlertNode.swift
@@ -13,7 +13,7 @@ public class PassPhraseAlertNode: ASDisplayNode {
     enum Constants {
         static let antiBruteForceProtectionAttemptsMaxValue = 5
         static let blockingTimeInSeconds: Double = 5 * 60
-        static let textColor = UIColor.colorFor(darkStyle: .white, lightStyle: .darkGray)
+        static let textColor = UIColor.colorFor(darkStyle: .white, lightStyle: .black)
         static let okayButtonColor = UIColor(hex: "4591FC") ?? .blue
     }
 

--- a/FlowCryptUI/Nodes/PassPhraseAlertNode.swift
+++ b/FlowCryptUI/Nodes/PassPhraseAlertNode.swift
@@ -15,6 +15,7 @@ public class PassPhraseAlertNode: ASDisplayNode {
         static let blockingTimeInSeconds: Double = 5 * 60
         static let textColor = UIColor.colorFor(darkStyle: .white, lightStyle: .black)
         static let okayButtonColor = UIColor(hex: "4591FC") ?? .blue
+        static let buttonFont = UIFont.boldSystemFont(ofSize: 16)
     }
 
     private lazy var overlayNode = createOverlayNode()
@@ -125,14 +126,14 @@ public class PassPhraseAlertNode: ASDisplayNode {
 
         okayButton.isEnabled = false
         let minuteSecondStr = convertToMinuteSecondFormat(seconds: Int(remainingTimeInSeconds))
-        okayButton.setTitle(minuteSecondStr, with: .boldSystemFont(ofSize: 16), with: .gray, for: .normal)
+        okayButton.setTitle(minuteSecondStr, with: Constants.buttonFont, with: .gray, for: .normal)
     }
 
     private func dismissBruteForceProtectionAlert() {
         if failedPassPhraseAttempts == 0 {
             introduction = nil
         }
-        okayButton.setTitle("Ok", with: UIFont.boldSystemFont(ofSize: 16), with: Constants.okayButtonColor, for: .normal)
+        okayButton.setTitle("Ok", with: Constants.buttonFont, with: Constants.okayButtonColor, for: .normal)
         okayButton.isEnabled = true
     }
 
@@ -199,7 +200,7 @@ public class PassPhraseAlertNode: ASDisplayNode {
 
     private func createButtonNode(title: String, color: UIColor, identifier: String, action: Selector) -> ASButtonNode {
         let node = ASButtonNode()
-        node.setTitle(title, with: UIFont.boldSystemFont(ofSize: 16), with: color, for: .normal)
+        node.setTitle(title, with: Constants.buttonFont, with: color, for: .normal)
         node.style.flexGrow = 1
         node.style.preferredSize.height = 35
         node.addTarget(self, action: action, forControlEvents: .touchUpInside)

--- a/FlowCryptUI/Nodes/PassPhraseAlertNode.swift
+++ b/FlowCryptUI/Nodes/PassPhraseAlertNode.swift
@@ -13,6 +13,7 @@ public class PassPhraseAlertNode: ASDisplayNode {
     enum Constants {
         static let antiBruteForceProtectionAttemptsMaxValue = 5
         static let blockingTimeInSeconds: Double = 5 * 60
+        static let textColor = UIColor.colorFor(darkStyle: .white, lightStyle: .darkGray)
     }
 
     private lazy var overlayNode = createOverlayNode()
@@ -23,7 +24,7 @@ public class PassPhraseAlertNode: ASDisplayNode {
     private lazy var introductionLabel = createTextNode(text: "", isBold: false, fontSize: 13, identifier: "aid-anti-brute-force-introduce-label")
     private lazy var passPhraseTextField = createPassPhraseTextField()
     private lazy var cancelButton = createButtonNode(title: "Cancel", color: .red, identifier: "aid-cancel-button", action: #selector(cancelButtonTapped))
-    private lazy var okayButton = createButtonNode(title: "Ok", color: .blue, identifier: "aid-ok-button", action: #selector(okayButtonTapped))
+    private lazy var okayButton = createButtonNode(title: "Ok", color: UIColor(hex: "4591FC") ?? .blue, identifier: "aid-ok-button", action: #selector(okayButtonTapped))
     private weak var alertTimer: Timer?
 
     private var introduction: String? { didSet { updateIntroduction() } }
@@ -154,7 +155,10 @@ public class PassPhraseAlertNode: ASDisplayNode {
 
     private func createContentView() -> ASDisplayNode {
         let node = ASDisplayNode()
-        node.backgroundColor = UIColor(hex: "F0F0F0")
+        node.backgroundColor = UIColor.colorFor(
+            darkStyle: UIColor(hex: "282828") ?? .black,
+            lightStyle: UIColor(hex: "F0F0F0") ?? .white
+        )
         node.clipsToBounds = true
         node.cornerRadius = 13
         node.shadowColor = UIColor.black.cgColor
@@ -182,26 +186,30 @@ public class PassPhraseAlertNode: ASDisplayNode {
         let font = isBold ? UIFont.boldSystemFont(ofSize: fontSize) : UIFont.systemFont(ofSize: fontSize)
         node.attributedText = NSAttributedString(
             string: text,
-            attributes: [NSAttributedString.Key.font: font]
+            attributes: [
+                .font: font,
+                .foregroundColor: Constants.textColor
+            ]
         )
+
         node.accessibilityIdentifier = identifier
         return node
     }
 
     private func createButtonNode(title: String, color: UIColor, identifier: String, action: Selector) -> ASButtonNode {
         let node = ASButtonNode()
-        node.setTitle(title, with: UIFont.systemFont(ofSize: 15), with: color, for: .normal)
+        node.setTitle(title, with: UIFont.boldSystemFont(ofSize: 16), with: color, for: .normal)
         node.style.flexGrow = 1
         node.style.preferredSize.height = 35
         node.addTarget(self, action: action, forControlEvents: .touchUpInside)
         node.accessibilityIdentifier = identifier
-        node.setBackgroundColor(.lightGray, forState: .highlighted)
+        node.setBackgroundColor(UIColor.colorFor(darkStyle: .darkGray, lightStyle: .lightGray), forState: .highlighted)
         return node
     }
 
     private func updateIntroduction() {
         if let introduction, !introduction.isEmpty {
-            introductionLabel.attributedText = NSAttributedString(string: introduction)
+            introductionLabel.attributedText = NSAttributedString(string: introduction, attributes: [.foregroundColor: Constants.textColor])
             introductionLabel.isHidden = false
         } else {
             introductionLabel.isHidden = true
@@ -220,9 +228,15 @@ public class PassPhraseAlertNode: ASDisplayNode {
             self.submitPassphrase(text: textField.text)
             return true
         }
-        node.borderColor = .init(gray: 0.2, alpha: 1.0)
+        node.borderColor = UIColor.colorFor(
+            darkStyle: .init(white: 0.8, alpha: 1.0),
+            lightStyle: .init(white: 0.2, alpha: 1.0)
+        ).cgColor
         node.borderWidth = 0.1
-        node.backgroundColor = .white
+        node.backgroundColor = UIColor.colorFor(
+            darkStyle: UIColor(hex: "1D1D1E") ?? .black,
+            lightStyle: .white
+        )
         node.cornerRadius = 6
         node.style.width = ASDimension(unit: .fraction, value: 1.0)
         node.style.preferredSize.height = 35

--- a/FlowCryptUI/Nodes/PassPhraseAlertNode.swift
+++ b/FlowCryptUI/Nodes/PassPhraseAlertNode.swift
@@ -14,6 +14,7 @@ public class PassPhraseAlertNode: ASDisplayNode {
         static let antiBruteForceProtectionAttemptsMaxValue = 5
         static let blockingTimeInSeconds: Double = 5 * 60
         static let textColor = UIColor.colorFor(darkStyle: .white, lightStyle: .darkGray)
+        static let okayButtonColor = UIColor(hex: "4591FC") ?? .blue
     }
 
     private lazy var overlayNode = createOverlayNode()
@@ -24,7 +25,7 @@ public class PassPhraseAlertNode: ASDisplayNode {
     private lazy var introductionLabel = createTextNode(text: "", isBold: false, fontSize: 13, identifier: "aid-anti-brute-force-introduce-label")
     private lazy var passPhraseTextField = createPassPhraseTextField()
     private lazy var cancelButton = createButtonNode(title: "Cancel", color: .red, identifier: "aid-cancel-button", action: #selector(cancelButtonTapped))
-    private lazy var okayButton = createButtonNode(title: "Ok", color: UIColor(hex: "4591FC") ?? .blue, identifier: "aid-ok-button", action: #selector(okayButtonTapped))
+    private lazy var okayButton = createButtonNode(title: "Ok", color: Constants.okayButtonColor, identifier: "aid-ok-button", action: #selector(okayButtonTapped))
     private weak var alertTimer: Timer?
 
     private var introduction: String? { didSet { updateIntroduction() } }
@@ -131,7 +132,7 @@ public class PassPhraseAlertNode: ASDisplayNode {
         if failedPassPhraseAttempts == 0 {
             introduction = nil
         }
-        okayButton.setTitle("Ok", with: UIFont.systemFont(ofSize: 15), with: .blue, for: .normal)
+        okayButton.setTitle("Ok", with: UIFont.boldSystemFont(ofSize: 15), with: Constants.okayButtonColor, for: .normal)
         okayButton.isEnabled = true
     }
 

--- a/FlowCryptUI/Nodes/PassPhraseAlertNode.swift
+++ b/FlowCryptUI/Nodes/PassPhraseAlertNode.swift
@@ -125,14 +125,14 @@ public class PassPhraseAlertNode: ASDisplayNode {
 
         okayButton.isEnabled = false
         let minuteSecondStr = convertToMinuteSecondFormat(seconds: Int(remainingTimeInSeconds))
-        okayButton.setTitle(minuteSecondStr, with: .systemFont(ofSize: 15), with: .gray, for: .normal)
+        okayButton.setTitle(minuteSecondStr, with: .boldSystemFont(ofSize: 16), with: .gray, for: .normal)
     }
 
     private func dismissBruteForceProtectionAlert() {
         if failedPassPhraseAttempts == 0 {
             introduction = nil
         }
-        okayButton.setTitle("Ok", with: UIFont.boldSystemFont(ofSize: 15), with: Constants.okayButtonColor, for: .normal)
+        okayButton.setTitle("Ok", with: UIFont.boldSystemFont(ofSize: 16), with: Constants.okayButtonColor, for: .normal)
         okayButton.isEnabled = true
     }
 


### PR DESCRIPTION
This PR implemented passphrase popup dark mode support 

close #2306 // if this PR closes an issue

![image](https://github.com/FlowCrypt/flowcrypt-ios/assets/77344191/6758cde1-688d-4d2a-aed2-5b97f43a1b4a)

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
