### PR TITLE
Fix: toast max height in compose draft error

### DIFF
--- a/FlowCrypt/Controllers/Compose/Extensions/ComposeViewController+Drafts.swift
+++ b/FlowCrypt/Controllers/Compose/Extensions/ComposeViewController+Drafts.swift
@@ -102,7 +102,7 @@ extension ComposeViewController {
                     showToast(
                         "draft_error".localizeWithArguments(error.errorMessage),
                         position: .top,
-                        view: self.navigationController?.navigationBar,
+                        view: self.navigationController?.navigationBar.superview,
                         maxHeightPercentage: 1.0
                     )
                 }


### PR DESCRIPTION
This PR fixed toast height for compose draft error

close #2398 // if this PR closes an issue

![image](https://github.com/FlowCrypt/flowcrypt-ios/assets/77344191/568f1f06-90db-45d5-bed4-0ab566809e86)

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
