### PR TITLE
#2421 feat: added ability to message recipient without valid public key

### DIFF
--- a/FlowCrypt/Controllers/Compose/Extensions/ComposeViewController+ErrorHandling.swift
+++ b/FlowCrypt/Controllers/Compose/Extensions/ComposeViewController+ErrorHandling.swift
@@ -107,7 +107,9 @@ extension ComposeViewController {
             style: .cancel
         )
         cancelAction.accessibilityIdentifier = "aid-cancel-button"
-        alert.addAction(sendUnEncryptedAction)
+        if !Bundle.isEnterprise {
+            alert.addAction(sendUnEncryptedAction) // Disallow sending plain message for enterprise
+        }
         if isMessagePasswordSupported {
             alert.addAction(sendPasswordProtectedAction)
         }

--- a/FlowCrypt/Controllers/Compose/Extensions/ComposeViewController+ErrorHandling.swift
+++ b/FlowCrypt/Controllers/Compose/Extensions/ComposeViewController+ErrorHandling.swift
@@ -101,7 +101,7 @@ extension ComposeViewController {
                 self?.setMessagePassword()
             }
         )
-        sendUnEncryptedAction.accessibilityIdentifier = "aid-compose-send-message-password"
+        sendPasswordProtectedAction.accessibilityIdentifier = "aid-compose-send-message-password"
         let cancelAction = UIAlertAction(
             title: "cancel".localized,
             style: .cancel

--- a/FlowCrypt/Controllers/Compose/Extensions/ComposeViewController+ErrorHandling.swift
+++ b/FlowCrypt/Controllers/Compose/Extensions/ComposeViewController+ErrorHandling.swift
@@ -66,17 +66,11 @@ extension ComposeViewController {
         }
 
         switch error {
-        case MessageValidationError.noPubRecipients:
-            guard isMessagePasswordSupported else {
-                showPlainMessageConfirmationAlert()
-                return
-            }
-
-            if Bundle.isEnterprise {
-                setMessagePassword()
-            } else {
-                showPlainMessageAlert()
-            }
+        case MessageValidationError.noPubRecipients,
+             MessageValidationError.revokedKeyRecipients,
+             MessageValidationError.expiredKeyRecipients,
+             MessageValidationError.notUsableForEncryptionKeyRecipients:
+            processSendMessageWithNoValidKeys(error: error)
         case MessageValidationError.notUniquePassword,
              MessageValidationError.subjectContainsPassword,
              MessageValidationError.weakPassword:
@@ -86,26 +80,39 @@ extension ComposeViewController {
         }
     }
 
-    private func showPlainMessageConfirmationAlert() {
-        showAlertWithAction(
+    private func processSendMessageWithNoValidKeys(error: Error) {
+        let alert = UIAlertController(
             title: "compose_message_encryption".localized,
-            message: "compose_plain_message_confirmation".localized,
-            actionButtonTitle: "compose_send_unencrypted".localized,
-            actionAccessibilityIdentifier: "aid-compose-send-plain",
-            onAction: { [weak self] _ in self?.handleSendTap(shouldSendPlainMessage: true) }
+            message: error.errorMessage,
+            preferredStyle: .alert
         )
-    }
-
-    private func showPlainMessageAlert() {
-        showAlertWithAction(
-            title: "compose_message_encryption".localized,
-            message: "compose_plain_message_alert".localized,
-            cancelButtonTitle: "compose_add_message_password".localized,
-            actionButtonTitle: "compose_send_unencrypted".localized,
-            actionAccessibilityIdentifier: "aid-compose-send-plain",
-            onAction: { [weak self] _ in self?.handleSendTap(shouldSendPlainMessage: true) },
-            onCancel: { [weak self] _ in self?.setMessagePassword() }
+        let sendUnEncryptedAction = UIAlertAction(
+            title: "compose_send_unencrypted".localized,
+            style: .default,
+            handler: { [weak self] _ in
+                self?.handleSendTap(shouldSendPlainMessage: true)
+            }
         )
+        sendUnEncryptedAction.accessibilityIdentifier = "aid-compose-send-plain"
+        let sendPasswordProtectedAction = UIAlertAction(
+            title: "compose_add_message_password".localized,
+            style: .default,
+            handler: { [weak self] _ in
+                self?.setMessagePassword()
+            }
+        )
+        sendUnEncryptedAction.accessibilityIdentifier = "aid-compose-send-message-password"
+        let cancelAction = UIAlertAction(
+            title: "cancel".localized,
+            style: .cancel
+        )
+        cancelAction.accessibilityIdentifier = "aid-cancel-button"
+        alert.addAction(sendUnEncryptedAction)
+        if isMessagePasswordSupported {
+            alert.addAction(sendPasswordProtectedAction)
+        }
+        alert.addAction(cancelAction)
+        present(alert, animated: true, completion: nil)
     }
 
     private func reEnableSendButton() {

--- a/FlowCrypt/Controllers/Compose/Extensions/ComposeViewController+TableView.swift
+++ b/FlowCrypt/Controllers/Compose/Extensions/ComposeViewController+TableView.swift
@@ -29,7 +29,7 @@ extension ComposeViewController: ASTableDelegate, ASTableDataSource {
         case (.main, .recipients(.cc)), (.main, .recipients(.bcc)):
             return !shouldShowEmailRecipientsLabel && shouldShowAllRecipientTypes ? 1 : 0
         case (.main, .password):
-            return isMessagePasswordSupported && contextToSend.hasRecipientsWithoutPubKey ? 1 : 0
+            return isMessagePasswordSupported && contextToSend.hasRecipientWithInvalidKey ? 1 : 0
         case (.main, .compose):
             return ComposePart.allCases.count
         case (.main, .attachments):

--- a/FlowCrypt/Functionality/Services/Compose Message Helper/ComposeMessageContext.swift
+++ b/FlowCrypt/Functionality/Services/Compose Message Helper/ComposeMessageContext.swift
@@ -55,6 +55,10 @@ extension ComposeMessageContext {
         recipients.contains(where: { $0.keyState == .active })
     }
 
+    var hasRecipientWithInvalidKey: Bool {
+        recipients.contains(where: { $0.keyState != .active })
+    }
+
     var hasRecipientsWithoutPubKey: Bool {
         recipients.contains(where: { $0.keyState == .empty })
     }

--- a/FlowCrypt/Functionality/Services/Compose Message Helper/ComposeMessageHelper.swift
+++ b/FlowCrypt/Functionality/Services/Compose Message Helper/ComposeMessageHelper.swift
@@ -232,13 +232,13 @@ final class ComposeMessageHelper {
             throw MessageValidationError.noPubRecipients
         }
 
-        guard !contains(keyState: .notUsableForEncryption) else {
+        guard hasMessagePassword || !contains(keyState: .notUsableForEncryption) else {
             throw MessageValidationError.notUsableForEncryptionKeyRecipients
         }
-        guard !contains(keyState: .expired) else {
+        guard hasMessagePassword || !contains(keyState: .expired) else {
             throw MessageValidationError.expiredKeyRecipients
         }
-        guard !contains(keyState: .revoked) else {
+        guard hasMessagePassword || !contains(keyState: .revoked) else {
             throw MessageValidationError.revokedKeyRecipients
         }
     }

--- a/FlowCrypt/Resources/en.lproj/Localizable.strings
+++ b/FlowCrypt/Resources/en.lproj/Localizable.strings
@@ -137,7 +137,7 @@
 "compose_sign_passphrase_required" = "Passphrase is required for message signing.";
 "compose_sign_passphrase_no_match" = "This pass phrase did not match your signing private key.";
 "compose_sign_no_keys" = "Cannot sign message: none of your %@ account keys can be used for sending address %@";
-"compose_password_placeholder" = "Tap to add password for recipients who don't have encryption set up.";
+"compose_password_placeholder" = "Tap to add password for recipients without encryption or those with an invalid public key.";
 "compose_password_set_message" = "Web portal password added";
 "compose_password_modal_title" = "Set web portal password";
 "compose_password_modal_message" = "The recipients will receive a link to read your message on a web portal, where they will need to enter this password.\n\nYou are responsible for sharing this password with recipients (use other medium to share the password - not email)\n\nPassword should include:\n- one uppercase\n- one lowercase\n- one number\n- one special character eg &/#\"-'_%-@,;:!*()\n- min 8 characters length";

--- a/appium/tests/data/index.ts
+++ b/appium/tests/data/index.ts
@@ -204,7 +204,7 @@ export const CommonData = {
     password: 'abcABC1*',
     modalMessage: `Set web portal password\nThe recipients will receive a link to read your message on a web portal, where they will need to enter this password.\n\nYou are responsible for sharing this password with recipients (use other medium to share the password - not email)\n\nPassword should include: - one uppercase - one lowercase - one number - one special character eg &/#"-'_%-@,;:!*() - min 8 characters length`,
     plainMessageModal:
-      'Message Encryption\n One or more of your recipients are missing a public key (marked in gray).\n\nPlease ask them to share it with you, or ask them to also set up FlowCrypt.',
+      'Message Encryption\nOne or more of your recipients are missing a public key (marked in gray).\n\nPlease ask them to share it with you, or ask them to also set up FlowCrypt.',
     emptyPasswordMessage: 'Tap to add password for recipients without encryption or those with an invalid public key.',
     addedPasswordMessage: 'Web portal password added',
     weakPasswordMessage:
@@ -222,9 +222,9 @@ export const CommonData = {
   errors: {
     wrongPassPhrase:
       'Error\n' + 'Could not compose message\n' + '\n' + 'This pass phrase did not match your signing private key.',
-    notUsableEncryptionPublicKey: `Message Encryption\n One or more of your recipients have sign-only public keys (marked in yellow).\n\nPlease ask them to send you updated public key. If this is an enterprise installation, please ask your systems admin.`,
-    expiredPublicKey: `Message Encryption\n One or more of your recipients have expired public keys (marked in orange).\n\nPlease ask them to send you updated public key. If this is an enterprise installation, please ask your systems admin.`,
-    revokedPublicKey: `Message Encryption\n One or more of your recipients have revoked public keys (marked in red).\n\nPlease ask them to send you a new public key. If this is an enterprise installation, please ask your systems admin.`,
+    notUsableEncryptionPublicKey: `Message Encryption\nOne or more of your recipients have sign-only public keys (marked in yellow).\n\nPlease ask them to send you updated public key. If this is an enterprise installation, please ask your systems admin.`,
+    expiredPublicKey: `Message Encryption\nOne or more of your recipients have expired public keys (marked in orange).\n\nPlease ask them to send you updated public key. If this is an enterprise installation, please ask your systems admin.`,
+    revokedPublicKey: `Message Encryption\nOne or more of your recipients have revoked public keys (marked in red).\n\nPlease ask them to send you a new public key. If this is an enterprise installation, please ask your systems admin.`,
     wrongPassPhraseOnLogin: 'Error\n' + 'Wrong pass phrase, please try again',
     attachmentDecryptKeyMismatchError:
       'Error decrypting attachment\n' +

--- a/appium/tests/data/index.ts
+++ b/appium/tests/data/index.ts
@@ -204,7 +204,7 @@ export const CommonData = {
     password: 'abcABC1*',
     modalMessage: `Set web portal password\nThe recipients will receive a link to read your message on a web portal, where they will need to enter this password.\n\nYou are responsible for sharing this password with recipients (use other medium to share the password - not email)\n\nPassword should include: - one uppercase - one lowercase - one number - one special character eg &/#"-'_%-@,;:!*() - min 8 characters length`,
     plainMessageModal:
-      'Message Encryption\n One or more of your recipients are missing a public key (marked in gray). Please ask them to share it with you, or ask them to also set up FlowCrypt.',
+      'Message Encryption\n One or more of your recipients are missing a public key (marked in gray).\n\nPlease ask them to share it with you, or ask them to also set up FlowCrypt.',
     emptyPasswordMessage: 'Tap to add password for recipients without encryption or those with an invalid public key.',
     addedPasswordMessage: 'Web portal password added',
     weakPasswordMessage:
@@ -222,9 +222,9 @@ export const CommonData = {
   errors: {
     wrongPassPhrase:
       'Error\n' + 'Could not compose message\n' + '\n' + 'This pass phrase did not match your signing private key.',
-    notUsableEncryptionPublicKey: `Message Encryption\n One or more of your recipients have sign-only public keys (marked in yellow). Please ask them to send you updated public key. If this is an enterprise installation, please ask your systems admin.`,
-    expiredPublicKey: `Message Encryption\n One or more of your recipients have expired public keys (marked in orange). Please ask them to send you updated public key. If this is an enterprise installation, please ask your systems admin.`,
-    revokedPublicKey: `Message Encryption\n One or more of your recipients have revoked public keys (marked in orredange). Please ask them to send you updated public key. If this is an enterprise installation, please ask your systems admin.`,
+    notUsableEncryptionPublicKey: `Message Encryption\n One or more of your recipients have sign-only public keys (marked in yellow).\n\nPlease ask them to send you updated public key. If this is an enterprise installation, please ask your systems admin.`,
+    expiredPublicKey: `Message Encryption\n One or more of your recipients have expired public keys (marked in orange).\n\nPlease ask them to send you updated public key. If this is an enterprise installation, please ask your systems admin.`,
+    revokedPublicKey: `Message Encryption\n One or more of your recipients have revoked public keys (marked in red).\n\nPlease ask them to send you a new public key. If this is an enterprise installation, please ask your systems admin.`,
     wrongPassPhraseOnLogin: 'Error\n' + 'Wrong pass phrase, please try again',
     attachmentDecryptKeyMismatchError:
       'Error decrypting attachment\n' +

--- a/appium/tests/data/index.ts
+++ b/appium/tests/data/index.ts
@@ -204,8 +204,8 @@ export const CommonData = {
     password: 'abcABC1*',
     modalMessage: `Set web portal password\nThe recipients will receive a link to read your message on a web portal, where they will need to enter this password.\n\nYou are responsible for sharing this password with recipients (use other medium to share the password - not email)\n\nPassword should include: - one uppercase - one lowercase - one number - one special character eg &/#"-'_%-@,;:!*() - min 8 characters length`,
     plainMessageModal:
-      "Message Encryption\n One or more of your recipients don't have encryption set up.\n\nPlease add a message password, or message will be sent unencrypted.",
-    emptyPasswordMessage: "Tap to add password for recipients who don't have encryption set up.",
+      'Message Encryption\n One or more of your recipients are missing a public key (marked in gray). Please ask them to share it with you, or ask them to also set up FlowCrypt.',
+    emptyPasswordMessage: 'Tap to add password for recipients without encryption or those with an invalid public key.',
     addedPasswordMessage: 'Web portal password added',
     weakPasswordMessage:
       "Error\nPassword didn't comply with company policy, which requires at least:\n\n- one uppercase - one lowercase - one number - one special character eg &/#\"-'_%-@,;:!*() - 8 characters length\n\nPlease update the password and re-send.",
@@ -220,36 +220,11 @@ export const CommonData = {
     subject: 'Honor reply-to address - plain',
   },
   errors: {
-    noPublicKey:
-      'Error\n' +
-      'Could not compose message\n' +
-      '\n' +
-      'One or more of your recipients are missing a public key (marked in gray).\n' +
-      '\n' +
-      'Please ask them to share it with you, or ask them to also set up FlowCrypt.',
     wrongPassPhrase:
       'Error\n' + 'Could not compose message\n' + '\n' + 'This pass phrase did not match your signing private key.',
-    notUsableEncryptionPublicKey:
-      'Error\n' +
-      'Could not compose message\n' +
-      '\n' +
-      'One or more of your recipients have sign-only public keys (marked in yellow).\n' +
-      '\n' +
-      'Please ask them to send you updated public key. If this is an enterprise installation, please ask your systems admin.',
-    expiredPublicKey:
-      'Error\n' +
-      'Could not compose message\n' +
-      '\n' +
-      'One or more of your recipients have expired public keys (marked in orange).\n' +
-      '\n' +
-      'Please ask them to send you updated public key. If this is an enterprise installation, please ask your systems admin.',
-    revokedPublicKey:
-      'Error\n' +
-      'Could not compose message\n' +
-      '\n' +
-      'One or more of your recipients have revoked public keys (marked in red).\n' +
-      '\n' +
-      'Please ask them to send you a new public key. If this is an enterprise installation, please ask your systems admin.',
+    notUsableEncryptionPublicKey: `Message Encryption\n One or more of your recipients have sign-only public keys (marked in yellow). Please ask them to send you updated public key. If this is an enterprise installation, please ask your systems admin.`,
+    expiredPublicKey: `Message Encryption\n One or more of your recipients have expired public keys (marked in orange). Please ask them to send you updated public key. If this is an enterprise installation, please ask your systems admin.`,
+    revokedPublicKey: `Message Encryption\n One or more of your recipients have revoked public keys (marked in orredange). Please ask them to send you updated public key. If this is an enterprise installation, please ask your systems admin.`,
     wrongPassPhraseOnLogin: 'Error\n' + 'Wrong pass phrase, please try again',
     attachmentDecryptKeyMismatchError:
       'Error decrypting attachment\n' +

--- a/appium/tests/helpers/ElementHelper.ts
+++ b/appium/tests/helpers/ElementHelper.ts
@@ -86,9 +86,13 @@ class ElementHelper {
     }
 
     await this.waitAndClick(element);
-    await this.waitAndClick(element);
-
+    await browser.pause(200);
     const selectAllButton = await $('~Select All');
+    // Check if 'Select All' is not displayed, if so, click the element again.
+    if (!(await selectAllButton.isDisplayed())) {
+      await this.waitAndClick(element);
+    }
+
     await this.waitAndClick(selectAllButton);
 
     await driver.sendKeys(['\b']); // backspace

--- a/appium/tests/helpers/TouchHelper.ts
+++ b/appium/tests/helpers/TouchHelper.ts
@@ -59,8 +59,12 @@ class TouchHelper {
         pressOptions = { x: width, y: height };
         break;
     }
+    await TouchHelper.tapScreenAt(pressOptions);
+  };
+
+  static tapScreenAt = async ({ x, y }: { x: number; y: number }) => {
     await driver.touchPerform([
-      { action: 'press', options: pressOptions },
+      { action: 'press', options: { x, y } },
       { action: 'wait', options: { ms: 100 } },
       { action: 'release', options: {} },
     ]);

--- a/appium/tests/screenobjects/attachment.screen.ts
+++ b/appium/tests/screenobjects/attachment.screen.ts
@@ -3,7 +3,7 @@ import ElementHelper from '../helpers/ElementHelper';
 
 const SELECTORS = {
   BACK_BTN: '~aid-back-button',
-  SYSTEM_BACK_BTN: '~Back',
+  SYSTEM_BACK_BTN: '~Browse', // Back button is named to Browse
   SAVE_BTN: '~aid-save-attachment-to-device',
   CANCEL_BTN: '~Cancel', // can't change aid for UIDocumentPickerViewController
 };

--- a/appium/tests/screenobjects/attachment.screen.ts
+++ b/appium/tests/screenobjects/attachment.screen.ts
@@ -3,7 +3,6 @@ import ElementHelper from '../helpers/ElementHelper';
 
 const SELECTORS = {
   BACK_BTN: '~aid-back-button',
-  SYSTEM_BACK_BTN: '~Browse', // Back button is named to Browse
   SAVE_BTN: '~aid-save-attachment-to-device',
   CANCEL_BTN: '~Cancel', // can't change aid for UIDocumentPickerViewController
 };
@@ -15,10 +14,6 @@ class AttachmentScreen extends BaseScreen {
 
   get backButton() {
     return $(SELECTORS.BACK_BTN);
-  }
-
-  get systemBackButton() {
-    return $(SELECTORS.SYSTEM_BACK_BTN);
   }
 
   get saveButton() {
@@ -42,7 +37,17 @@ class AttachmentScreen extends BaseScreen {
   clickSystemBackButton = async () => {
     // Due to a issue in SemaphoreCI environment, a single back button click does not yield the expected behavior.
     // Therefore, we have implemented a mechanism to continuously click the system back button until cancel button appears.
-    await ElementHelper.clickUntilExpectedElementAppears(await this.systemBackButton, await this.cancelButton, 10);
+    await browser.pause(1000);
+    let systemBackButton = await $('~Back');
+    if (!(await systemBackButton.isDisplayed())) {
+      const browseButton = await $('~Browse'); // Back button is renamed to Browse in newer iOS versions
+      if (await browseButton.isDisplayed()) {
+        systemBackButton = browseButton;
+      } else {
+        throw new Error('System backup button is not displayed either using Back or Browse selector');
+      }
+    }
+    await ElementHelper.clickUntilExpectedElementAppears(systemBackButton, await this.cancelButton, 10);
   };
 
   clickCancelButton = async () => {

--- a/appium/tests/screenobjects/new-message.screen.ts
+++ b/appium/tests/screenobjects/new-message.screen.ts
@@ -395,6 +395,10 @@ class NewMessageScreen extends BaseScreen {
     await ElementHelper.waitAndClick(await this.sendButton);
   };
 
+  checkSendPlainMessageButtonNotPresent = async () => {
+    await ElementHelper.waitElementInvisible(await this.sendPlainMessageButton);
+  };
+
   clickSendPlainMessageButton = async () => {
     await ElementHelper.waitAndClick(await this.sendPlainMessageButton);
   };

--- a/appium/tests/screenobjects/new-message.screen.ts
+++ b/appium/tests/screenobjects/new-message.screen.ts
@@ -195,8 +195,8 @@ class NewMessageScreen extends BaseScreen {
     }
     await ElementHelper.waitElementInvisible(await this.recipientSpinner);
     await this.showRecipientLabelIfNeeded();
-    await this.setSubject(subject);
     await this.setComposeSecurityMessage(message);
+    await this.setSubject(subject);
   };
 
   changeFromEmail = async (email: string) => {

--- a/appium/tests/screenobjects/new-message.screen.ts
+++ b/appium/tests/screenobjects/new-message.screen.ts
@@ -177,6 +177,10 @@ class NewMessageScreen extends BaseScreen {
   setComposeSecurityMessage = async (message: string) => {
     await browser.pause(500);
     const el = await this.composeSecurityMessage;
+    // click message field so that message field is focused
+    // https://github.com/FlowCrypt/flowcrypt-ios/pull/2429#discussion_r1389511041
+    const location = await el.getLocation();
+    await TouchHelper.tapScreenAt({ x: location.x + 5, y: location.y + 5 });
     await ElementHelper.clearInput(el);
     await ElementHelper.waitClickAndType(el, message);
   };

--- a/appium/tests/screenobjects/new-message.screen.ts
+++ b/appium/tests/screenobjects/new-message.screen.ts
@@ -195,8 +195,8 @@ class NewMessageScreen extends BaseScreen {
     }
     await ElementHelper.waitElementInvisible(await this.recipientSpinner);
     await this.showRecipientLabelIfNeeded();
-    await this.setComposeSecurityMessage(message);
     await this.setSubject(subject);
+    await this.setComposeSecurityMessage(message);
   };
 
   changeFromEmail = async (email: string) => {

--- a/appium/tests/specs/mock/composeEmail/CheckSignOnlyKey.spec.ts
+++ b/appium/tests/specs/mock/composeEmail/CheckSignOnlyKey.spec.ts
@@ -39,7 +39,7 @@ describe('COMPOSE EMAIL: ', () => {
       await NewMessageScreen.composeEmail(recipient.email, subject, message);
       await NewMessageScreen.clickSendButton();
       await BaseScreen.checkModalMessage(notUsableEncryptionPublicKeyError);
-      await BaseScreen.clickOkButtonOnError();
+      await BaseScreen.clickCancelButton();
 
       // Stage2: Now try to encrypt & send message for user which contains sign only key & normal key and check if message is sent correctly
       mockApi.attesterConfig = {

--- a/appium/tests/specs/mock/composeEmail/SendEmailToRecipientWithExpiredAndRevokedPublicKeys.spec.ts
+++ b/appium/tests/specs/mock/composeEmail/SendEmailToRecipientWithExpiredAndRevokedPublicKeys.spec.ts
@@ -46,7 +46,7 @@ describe('COMPOSE EMAIL: ', () => {
 
       await BaseScreen.checkModalMessage(expiredPublicKeyError);
 
-      await BaseScreen.clickOkButtonOnError();
+      await BaseScreen.clickCancelButton();
       await NewMessageScreen.clickBackButton();
       await MailFolderScreen.checkInboxScreen();
 

--- a/appium/tests/specs/mock/composeEmail/SendEmailToRecipientWithoutPublicKey.spec.ts
+++ b/appium/tests/specs/mock/composeEmail/SendEmailToRecipientWithoutPublicKey.spec.ts
@@ -12,6 +12,7 @@ import BaseScreen from '../../../screenobjects/base.screen';
 import { MockApi } from 'api-mocks/mock';
 import { MockApiConfig } from 'api-mocks/mock-config';
 import { MockUserList } from 'api-mocks/mock-data';
+import AppiumHelper from 'tests/helpers/AppiumHelper';
 
 describe('COMPOSE EMAIL: ', () => {
   it('sending message to user without public key produces password modal', async () => {
@@ -26,6 +27,8 @@ describe('COMPOSE EMAIL: ', () => {
     const emptyPasswordMessage = CommonData.recipientWithoutPublicKey.emptyPasswordMessage;
     const subjectPasswordErrorMessage = CommonData.recipientWithoutPublicKey.subjectPasswordErrorMessage;
     const addedPasswordMessage = CommonData.recipientWithoutPublicKey.addedPasswordMessage;
+
+    const enterpriseProcessArgs = [...CommonData.mockProcessArgs, ...['--enterprise']];
 
     const mockApi = new MockApi();
 
@@ -91,6 +94,20 @@ describe('COMPOSE EMAIL: ', () => {
 
       await EmailScreen.checkOpenedEmail(sender, emailSubject, emailText);
       await EmailScreen.checkEncryptionBadge('not encrypted');
+
+      // check if enterprise doesn't allow to send non-encrypted message
+      await AppiumHelper.restartApp(enterpriseProcessArgs);
+
+      await MailFolderScreen.checkInboxScreen();
+      await MailFolderScreen.clickCreateEmail();
+      await NewMessageScreen.composeEmail(recipient, emailSubject, emailText);
+      await NewMessageScreen.checkFilledComposeEmailInfo({
+        recipients: [recipient],
+        subject: emailSubject,
+        message: emailText,
+      });
+      await NewMessageScreen.clickSendButton();
+      await NewMessageScreen.checkSendPlainMessageButtonNotPresent();
     });
   });
 });

--- a/appium/tests/specs/mock/composeEmail/SendEmailToRecipientWithoutPublicKey.spec.ts
+++ b/appium/tests/specs/mock/composeEmail/SendEmailToRecipientWithoutPublicKey.spec.ts
@@ -12,7 +12,6 @@ import BaseScreen from '../../../screenobjects/base.screen';
 import { MockApi } from 'api-mocks/mock';
 import { MockApiConfig } from 'api-mocks/mock-config';
 import { MockUserList } from 'api-mocks/mock-data';
-import AppiumHelper from 'tests/helpers/AppiumHelper';
 
 describe('COMPOSE EMAIL: ', () => {
   it('sending message to user without public key produces password modal', async () => {
@@ -24,12 +23,9 @@ describe('COMPOSE EMAIL: ', () => {
     const emailPassword = CommonData.recipientWithoutPublicKey.password;
 
     const plainMessageModal = CommonData.recipientWithoutPublicKey.plainMessageModal;
-    const passwordModalMessage = CommonData.recipientWithoutPublicKey.modalMessage;
     const emptyPasswordMessage = CommonData.recipientWithoutPublicKey.emptyPasswordMessage;
     const subjectPasswordErrorMessage = CommonData.recipientWithoutPublicKey.subjectPasswordErrorMessage;
     const addedPasswordMessage = CommonData.recipientWithoutPublicKey.addedPasswordMessage;
-
-    const enterpriseProcessArgs = [...CommonData.mockProcessArgs, ...['--enterprise']];
 
     const mockApi = new MockApi();
 
@@ -58,8 +54,6 @@ describe('COMPOSE EMAIL: ', () => {
       await BaseScreen.checkModalMessage(plainMessageModal);
       await NewMessageScreen.clickCancelButton();
 
-      await BaseScreen.checkModalMessage(passwordModalMessage);
-      await NewMessageScreen.clickCancelButton();
       await NewMessageScreen.checkPasswordCell(emptyPasswordMessage);
 
       await NewMessageScreen.deleteAddedRecipient(0);
@@ -67,8 +61,6 @@ describe('COMPOSE EMAIL: ', () => {
       await NewMessageScreen.setAddRecipient(recipient);
       await NewMessageScreen.clickSendButton();
       await BaseScreen.checkModalMessage(plainMessageModal);
-      await NewMessageScreen.clickCancelButton();
-      await BaseScreen.checkModalMessage(passwordModalMessage);
       await NewMessageScreen.clickCancelButton();
       await NewMessageScreen.checkPasswordCell(emptyPasswordMessage);
 
@@ -99,20 +91,6 @@ describe('COMPOSE EMAIL: ', () => {
 
       await EmailScreen.checkOpenedEmail(sender, emailSubject, emailText);
       await EmailScreen.checkEncryptionBadge('not encrypted');
-
-      // check if enterprise doesn't allow to send non-encrypted message
-      await AppiumHelper.restartApp(enterpriseProcessArgs);
-
-      await MailFolderScreen.checkInboxScreen();
-      await MailFolderScreen.clickCreateEmail();
-      await NewMessageScreen.composeEmail(recipient, emailSubject, emailText);
-      await NewMessageScreen.checkFilledComposeEmailInfo({
-        recipients: [recipient],
-        subject: emailSubject,
-        message: emailText,
-      });
-      await NewMessageScreen.clickSendButton();
-      await BaseScreen.checkModalMessage(passwordModalMessage);
     });
   });
 });


### PR DESCRIPTION
This PR added ability to message recipient without valid public key

close #2421 // if this PR closes an issue

https://github.com/FlowCrypt/flowcrypt-ios/assets/77344191/ad6eacc7-b451-485b-9cb8-ef6a549d4d78


----------------------------------

**Tests** _(delete all except exactly one)_:
- Tests added or updated

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
