### PR TITLE
#2660 Fix: sending a secure reply using the created draft produces a new thread issue

### DIFF
--- a/FlowCrypt/Functionality/Mail Provider/Message Provider/Gmail+Message.swift
+++ b/FlowCrypt/Functionality/Mail Provider/Message Provider/Gmail+Message.swift
@@ -21,7 +21,10 @@ extension GmailService: MessageProvider {
 
         let query = createMessageQuery(identifier: identifier, format: kGTLRGmailFormatFull)
         return try await withCheckedThrowingContinuation { continuation in
-            self.gmailService.executeQuery(query) { _, data, error in
+            self.gmailService.executeQuery(query) {
+                _,
+                data,
+                error in
                 if let error {
                     return continuation.resume(throwing: GmailApiError.providerError(error))
                 }

--- a/FlowCrypt/Functionality/Mail Provider/Message Provider/Gmail+MessageExtension.swift
+++ b/FlowCrypt/Functionality/Mail Provider/Message Provider/Gmail+MessageExtension.swift
@@ -44,6 +44,7 @@ extension Message {
         var replyTo: String?
         var inReplyTo: String?
         var rfc822MsgId: String?
+        var replyToMsgId: String?
         var isSuspicious = false
 
         for messageHeader in messageHeaders.compactMap({ $0 }) {
@@ -58,7 +59,9 @@ extension Message {
             case .cc: cc = value
             case .bcc: bcc = value
             case .replyTo: replyTo = value
-            case .inReplyTo: inReplyTo = value
+            case .inReplyTo:
+                inReplyTo = value
+                replyToMsgId = value
             case .receivedSPF: isSuspicious = value.contains("softfail")
             case .identifier: rfc822MsgId = value
             default: break
@@ -84,6 +87,7 @@ extension Message {
             bcc: bcc,
             replyTo: replyTo,
             inReplyTo: inReplyTo,
+            replyToMsgId: replyToMsgId,
             isSuspicious: isSuspicious
         )
     }


### PR DESCRIPTION
This PR fixed sending a secure reply using the created draft produces a new thread issue

close #2660 // if this PR closes an issue

----------------------------------

**Tests** _(delete all except exactly one)_:
- Difficult to test (Hard to test in CI mode)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [x] addresses the issue it closes (if any)
- [x] code is readable and understandable
- [x] is accompanied with tests, or tests are not needed
- [x] is free of vulnerabilities
- [x] is documented clearly and usefully, or doesn't need documentation
