### PR TITLE
#2690 Updated to use xcode 26 in semaphoreci

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -3,7 +3,7 @@ name: FlowCrypt iOS App
 agent:
   machine:
     type: a2-standard-4
-    os_image: macos-xcode16
+    os_image: macos-xcode26
 execution_time_limit:
   minutes: 80
 auto_cancel:

--- a/appium/config/wdio.live.conf.ts
+++ b/appium/config/wdio.live.conf.ts
@@ -10,8 +10,8 @@ config.capabilities = [
     platformName: 'iOS',
     hostname: '127.0.0.1',
     'appium:automationName': 'XCUITest',
-    'appium:deviceName': 'iPhone 16',
-    'appium:platformVersion': '18.5',
+    'appium:deviceName': 'iPhone 17',
+    'appium:platformVersion': '26.0',
     'appium:app': join(process.cwd(), './FlowCrypt.app'),
   },
 ];

--- a/appium/config/wdio.mock.conf.ts
+++ b/appium/config/wdio.mock.conf.ts
@@ -20,8 +20,8 @@ config.capabilities = [
     'appium:processArguments': {
       args: ['--mock-fes-api', '--mock-attester-api', '--mock-gmail-api'],
     },
-    'appium:deviceName': 'iPhone 16',
-    'appium:platformVersion': '18.5',
+    'appium:deviceName': 'iPhone 17',
+    'appium:platformVersion': '26.0',
     'appium:orientation': 'PORTRAIT',
     'appium:app': join(process.cwd(), './FlowCrypt.app'),
     'appium:simulatorStartupTimeout': 600000,


### PR DESCRIPTION
This PR updated to use xcode 26 in semaphoreci

close #2690 // if this PR closes an issue

----------------------------------

**Tests** _(delete all except exactly one)_:
- Does not need tests (refactor only, docs or internal changes)

--------------------------------

### To be filled by reviewers

I have reviewed that this PR... _(tick whichever items you personally focused on during this review)_:
- [ ] addresses the issue it closes (if any)
- [ ] code is readable and understandable
- [ ] is accompanied with tests, or tests are not needed
- [ ] is free of vulnerabilities
- [ ] is documented clearly and usefully, or doesn't need documentation
